### PR TITLE
[dependency] Querydsl 의존성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ Temporary Items
 
 application-local.yml
 application-dev.yml
+
+# Qclass
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,27 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Query log
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QClass path
+def generated = 'src/main/generated'
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
 }


### PR DESCRIPTION
## Related Issue 📌
close #5

## Description ✔️
- Querydsl 의존성 추가 
- Q클래스 파일 생성 경로 지정 -> 안해주면 인텔리제이 설정에 따라 생성경로 달라짐 - ['프로젝트 셋팅'참고](https://velog.io/@seojin5565/Querydsl-Spring-Data-JPA%EC%97%90%EC%84%9C-Querydsl%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EC%9E%901-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%85%8B%ED%8C%85)
- .gitignore에 생성 경로 추가

## To Reviewers
Querydsl 버전 5.0.0
충돌날까봐 미리합니다