### PR TITLE
[feat] redis 의존성 추가 및 유저의 대학교 설정 정보 저장 및 조회 api 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	// Feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package org.hankki.hankkiserver.api.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.dto.HankkiResponse;
+import org.hankki.hankkiserver.api.user.controller.request.UserUniversityPostRequest;
+import org.hankki.hankkiserver.api.user.service.UserCommandService;
+import org.hankki.hankkiserver.api.user.service.UserQueryService;
+import org.hankki.hankkiserver.api.user.service.command.UserUniversityPostCommand;
+import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
+import org.hankki.hankkiserver.auth.UserId;
+import org.hankki.hankkiserver.common.code.CommonSuccessCode;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserCommandService userCommandService;
+
+    @PostMapping("/users/me/university")
+    public HankkiResponse<Void> postUserUniversity(@UserId final Long userId,
+                                                @Valid @RequestBody final UserUniversityPostRequest request) {
+        userCommandService.saveUserUniversity(new UserUniversityPostCommand(userId, request));
+        return HankkiResponse.success(CommonSuccessCode.CREATED);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
@@ -18,11 +18,17 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     @PostMapping("/users/me/university")
     public HankkiResponse<Void> postUserUniversity(@UserId final Long userId,
                                                 @Valid @RequestBody final UserUniversityPostRequest request) {
         userCommandService.saveUserUniversity(new UserUniversityPostCommand(userId, request));
         return HankkiResponse.success(CommonSuccessCode.CREATED);
+    }
+
+    @GetMapping("/users/me/university")
+    public HankkiResponse<UserUniversityFindResponse> findUserUniversity(@UserId final Long userId) {
+        return HankkiResponse.success(CommonSuccessCode.OK, userQueryService.findUserUniversity(userId));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/request/UserUniversityPostRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/request/UserUniversityPostRequest.java
@@ -1,0 +1,7 @@
+package org.hankki.hankkiserver.api.user.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserUniversityPostRequest(long universityId, @NotBlank @Size(max = 5) String name, double longitude, double latitude) {
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserCommandService.java
@@ -1,0 +1,22 @@
+package org.hankki.hankkiserver.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.user.service.command.UserUniversityPostCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandService {
+
+    private final UserUniversityUpdater userUniversityUpdater;
+    private final UserUniversityDeleter userUniversityDeleter;
+    private final UserUniversityFinder userUniversityFinder;
+
+    @Transactional
+    public void saveUserUniversity(UserUniversityPostCommand userUniversityPostCommand) {
+        userUniversityFinder.findByUserId(userUniversityPostCommand.userId())
+                        .ifPresent(userUniversity -> userUniversityDeleter.deleteById(userUniversity.getId()));
+        userUniversityUpdater.save(userUniversityPostCommand.toEntity());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -1,0 +1,21 @@
+package org.hankki.hankkiserver.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
+import org.hankki.hankkiserver.common.code.UserUniversityErrorCode;
+import org.hankki.hankkiserver.common.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserUniversityFinder userUniversityFinder;
+
+    @Transactional(readOnly = true)
+    public UserUniversityFindResponse findUserUniversity(Long userId) {
+        return UserUniversityFindResponse.of(userUniversityFinder.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserUniversityErrorCode.USER_UNIVERSITY_NOT_FOUND)));
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityDeleter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityDeleter.java
@@ -1,0 +1,20 @@
+package org.hankki.hankkiserver.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.user.repository.UserUniversityRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserUniversityDeleter {
+
+    private final UserUniversityRepository userUniversityRepository;
+
+    protected void deleteById(Long id) {
+        userUniversityRepository.deleteById(id);
+    }
+
+    protected void deleteByUserId(Long userId) {
+        userUniversityRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityFinder.java
@@ -1,0 +1,19 @@
+package org.hankki.hankkiserver.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.user.model.UserUniversity;
+import org.hankki.hankkiserver.domain.user.repository.UserUniversityRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserUniversityFinder {
+
+    private final UserUniversityRepository userUniversityRepository;
+
+    public Optional<UserUniversity> findByUserId(Long userId) {
+        return userUniversityRepository.findByUserId(userId);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityUpdater.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserUniversityUpdater.java
@@ -1,0 +1,17 @@
+package org.hankki.hankkiserver.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.user.model.UserUniversity;
+import org.hankki.hankkiserver.domain.user.repository.UserUniversityRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserUniversityUpdater {
+
+    private final UserUniversityRepository userUniversityRepository;
+
+    protected void save(UserUniversity userUniversity) {
+        userUniversityRepository.save(userUniversity).getUserId();
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/command/UserUniversityPostCommand.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/command/UserUniversityPostCommand.java
@@ -1,0 +1,22 @@
+package org.hankki.hankkiserver.api.user.service.command;
+
+import org.hankki.hankkiserver.api.user.controller.request.UserUniversityPostRequest;
+import org.hankki.hankkiserver.domain.user.model.UserUniversity;
+
+public record UserUniversityPostCommand(Long userId, Long universityId, String universityName,
+                                        double longitude, double latitude) {
+    public UserUniversityPostCommand(Long userId, UserUniversityPostRequest request) {
+        this(userId, request.universityId(), request.name(), request.longitude(), request.latitude());
+    }
+
+    public UserUniversity toEntity() {
+        return UserUniversity.builder()
+            .userId(userId)
+            .universityId(universityId)
+            .universityName(universityName)
+            .longitude(longitude)
+            .latitude(latitude)
+            .build();
+    }
+}
+

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserUniversityFindResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserUniversityFindResponse.java
@@ -1,0 +1,13 @@
+package org.hankki.hankkiserver.api.user.service.response;
+
+import org.hankki.hankkiserver.domain.user.model.UserUniversity;
+
+public record UserUniversityFindResponse(long id,
+                                         String name,
+                                         double longitude,
+                                         double latitude) {
+    public static UserUniversityFindResponse of (UserUniversity userUniversity) {
+         return new UserUniversityFindResponse(userUniversity.getUniversityId(), userUniversity.getUniversityName(),
+                userUniversity.getLongitude(), userUniversity.getLatitude());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/common/code/UserUniversityErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/UserUniversityErrorCode.java
@@ -1,0 +1,14 @@
+package org.hankki.hankkiserver.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserUniversityErrorCode implements ErrorCode {
+    USER_UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "대학 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/user/model/UserUniversity.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/user/model/UserUniversity.java
@@ -1,0 +1,30 @@
+package org.hankki.hankkiserver.domain.user.model;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "UserUniversity", timeToLive = 60 * 60 * 24 * 1000L * 30)
+@Builder
+@AllArgsConstructor
+@Getter
+public class UserUniversity {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private Long userId;
+
+    private Long universityId;
+
+    private String universityName;
+
+    private Double longitude;
+
+    private Double latitude;
+
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/user/repository/UserUniversityRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/user/repository/UserUniversityRepository.java
@@ -1,0 +1,12 @@
+package org.hankki.hankkiserver.domain.user.repository;
+
+import org.hankki.hankkiserver.domain.user.model.UserUniversity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface UserUniversityRepository extends CrudRepository<UserUniversity, Long> {
+    Optional<UserUniversity> findByUserId(Long userId);
+    void deleteById(Long id);
+    void deleteByUserId(Long userId);
+}


### PR DESCRIPTION
## Related Issue 📌
close #37 

## Description ✔️
- deploy.sh 내에
```shell
# Redis 상태 체크 및 docker-compose 실행
redis_status=$(echo $response | jq -r '.components.redis.status')
if [ "$redis_status" == "DOWN" ]; then
    echo "> Redis 상태가 DOWN입니다. docker-compose up -d 실행"
    docker-compose up -d
fi
```
추가하여 redis가 다운일때만 docker-compose up -d 실행하도록 했습니다.

- ec2 루트 디렉토리에 docker-compose.yml 추가
```
services:
  redis:
    container_name: redis
    image: redis:alpine
    hostname: redis
    ports:
      - "6379:6379"
    networks:
      - wascomposenet
  networks:
    wascomposenet:
      external: true
```

- `docker network create wascomposenet` 실행하여 
Docker에서 사용자 정의 네트워크를 생성
wascomposenet을 사용해 컨테이너 간의 통신 가능하게 함

## To Reviewers
