### PR TITLE
[fix] 소셜 로그인 오류 수정

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/JwtAuthenticationEntryPoint.java
@@ -12,7 +12,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -20,10 +19,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public void commence(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            AuthenticationException authException) throws IOException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         handleException(response);
     }
 
@@ -31,14 +27,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         setResponse(response, HttpStatus.UNAUTHORIZED, AuthErrorCode.UNAUTHORIZED);
     }
 
-    private void setResponse(
-            HttpServletResponse response,
-            HttpStatus httpStatus,
-            AuthErrorCode authErrorCode) throws IOException {
+    private void setResponse(HttpServletResponse response, HttpStatus httpStatus, AuthErrorCode authErrorCode) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
         response.setStatus(httpStatus.value());
-        PrintWriter writer = response.getWriter();
-        writer.write(objectMapper.writeValueAsString(HankkiResponse.fail(authErrorCode)));
+        response.getWriter().write(objectMapper.writeValueAsString(HankkiResponse.fail(authErrorCode)));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import org.hankki.hankkiserver.auth.UserAuthentication;
 import org.hankki.hankkiserver.auth.jwt.JwtProvider;
 import org.hankki.hankkiserver.auth.jwt.JwtValidator;
 import org.hankki.hankkiserver.common.code.AuthErrorCode;
+import org.hankki.hankkiserver.common.code.ErrorCode;
 import org.hankki.hankkiserver.common.exception.UnauthorizedException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,12 +30,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
 
     @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String accessToken = getAccessToken(request);
-        jwtValidator.validateAccessToken(accessToken);
+        jwtValidator.validateAccessToken(accessToken, request.getRequestURI());
         doAuthentication(request, jwtProvider.getSubject(accessToken));
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/org/hankki/hankkiserver/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/filter/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String accessToken = getAccessToken(request);
-        jwtValidator.validateAccessToken(accessToken, request.getRequestURI());
+        jwtValidator.validateAccessToken(accessToken);
         doAuthentication(request, jwtProvider.getSubject(accessToken));
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtGenerator.java
@@ -1,9 +1,7 @@
 package org.hankki.hankkiserver.auth.jwt;
 
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,12 +20,20 @@ public class JwtGenerator {
     @Value("${jwt.refresh-token-expiration}")
     private long REFRESH_TOKEN_EXPIRE_TIME;
 
-    public String generateToken(Long userId, boolean isAccessToken) {
+    public static final String USER_ROLE_CLAIM_NAME = "role";
+
+    public String generateToken(Long userId, String role, boolean isAccessToken) {
         final Date now = generateNowDate();
         final Date expiration = generateExpirationDate(isAccessToken, now);
+
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        if (isAccessToken) {
+            claims.put(USER_ROLE_CLAIM_NAME, role);
+        }
+
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(String.valueOf(userId))
+                .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expiration)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtGenerator.java
@@ -1,7 +1,6 @@
 package org.hankki.hankkiserver.auth.jwt;
 
 import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -55,7 +54,8 @@ public class JwtGenerator {
     }
 
     private Key getSigningKey() {
-        return Keys.hmacShaKeyFor(encodeSecretKey().getBytes());
+        byte[] keyBytes = Base64.getDecoder().decode(JWT_SECRET);
+        return Keys.hmacShaKeyFor(keyBytes);
     }
 
     private long calculateExpirationTime(boolean isAccessToken) {
@@ -64,10 +64,4 @@ public class JwtGenerator {
         }
         return REFRESH_TOKEN_EXPIRE_TIME;
     }
-
-    private String encodeSecretKey() {
-        return Base64.getEncoder()
-                .encodeToString(JWT_SECRET.getBytes());
-    }
 }
-

--- a/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtProvider.java
@@ -10,9 +10,9 @@ public class JwtProvider {
 
     private final JwtGenerator jwtGenerator;
 
-    public Token issueTokens(Long userId) {
-        return Token.of(jwtGenerator.generateToken(userId, true),
-                jwtGenerator.generateToken(userId, false));
+    public Token issueTokens(Long userId, String role) {
+        return Token.of(jwtGenerator.generateToken(userId, role, true),
+                jwtGenerator.generateToken(userId, role, false));
     }
 
     public Long getSubject(String token) {

--- a/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtValidator.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtValidator.java
@@ -17,7 +17,7 @@ public class JwtValidator {
 
     private final JwtGenerator jwtGenerator;
 
-    public void validateAccessToken(String accessToken, String requestURI) {
+    public void validateAccessToken(String accessToken) {
         try {
             String role = parseToken(accessToken).get(JwtGenerator.USER_ROLE_CLAIM_NAME, String.class);
             if (role == null) {

--- a/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtValidator.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/jwt/JwtValidator.java
@@ -21,9 +21,7 @@ public class JwtValidator {
         try {
             String role = parseToken(accessToken).get(JwtGenerator.USER_ROLE_CLAIM_NAME, String.class);
             if (role == null) {
-                if (!requestURI.equals("/api/v1/auth/reissue")) {
-                    throw new UnauthorizedException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
-                }
+                throw new UnauthorizedException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
             }
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(AuthErrorCode.EXPIRED_ACCESS_TOKEN);

--- a/src/main/java/org/hankki/hankkiserver/common/exception/UnauthorizedException.java
+++ b/src/main/java/org/hankki/hankkiserver/common/exception/UnauthorizedException.java
@@ -1,7 +1,6 @@
 package org.hankki.hankkiserver.common.exception;
 
 import lombok.Getter;
-import org.hankki.hankkiserver.common.code.AuthErrorCode;
 import org.hankki.hankkiserver.common.code.ErrorCode;
 
 @Getter
@@ -12,6 +11,5 @@ public class UnauthorizedException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
-
 }
 


### PR DESCRIPTION
## Related Issue 📌
close #44 

## Description ✔️
accessToken claims에 role 추가해서 role 존재 여부로 refreshToken과 accessToken을 구분하였습니다. 

filter chain을 bean으로 등록하지 않았기에 WhiteList에 등록된 url은 필터를 거치지 않음 -> 때문에 reissue api의 경우 white list에 등록을 해두었기 때문에 따로 filter에서 refreshToken으로 요청이 들어왔을 때 해당 request api가 reissue api인지 검증하는 로직은 제외하였습니다. 즉, refresh Token으로 들어오는 모든 요청에 대해서 예외를 던졌습니다. 

---
또한 비밀키를 인코딩하는 로직에 오류가 있어서 이 또한 수정했습니다. 
(이 과정에서 yml 파일이 조금 바뀌었습니다. submodule update 해주세요)

## To Reviewers
yml 파일 업데이트 되었습니다.