### PR TITLE
[feat] 식당 썸네일 조회 api 생성

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -6,8 +6,10 @@ import org.hankki.hankkiserver.api.store.service.StoreQueryService;
 import org.hankki.hankkiserver.api.store.service.response.CategoriesResponse;
 import org.hankki.hankkiserver.api.store.service.response.PriceCategoriesResponse;
 import org.hankki.hankkiserver.api.store.service.response.SortOptionsResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoreThumbnailResponse;
 import org.hankki.hankkiserver.common.code.CommonSuccessCode;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     private final StoreQueryService storeQueryService;
+
+    @GetMapping("/stores/{id}/thumbnail")
+    public HankkiResponse<StoreThumbnailResponse> getStoreThumbnail(@PathVariable Long id) {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreThumbnail(id));
+    }
 
     @GetMapping("/stores/categories")
     public HankkiResponse<CategoriesResponse> getCategories() {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -1,0 +1,20 @@
+package org.hankki.hankkiserver.api.store.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.common.exception.NotFoundException;
+import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.store.repository.StoreRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StoreFinder {
+
+    private final StoreRepository storeRepository;
+
+    protected Store findByIdWhereDeletedIsFalse(Long id) {
+        return storeRepository.findByIdAndIsDeletedIsFalse(id)
+                .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -1,16 +1,27 @@
 package org.hankki.hankkiserver.api.store.service;
 
 
+import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.*;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 
 @Service
+@RequiredArgsConstructor
 public class StoreQueryService {
+
+    private final StoreFinder storeFinder;
+
+    @Transactional(readOnly = true)//주어진 pk를 가진 식당의 정보를 조회 이때 식당의 상태가 is_deleted면 404를 나타낸다.
+    public StoreThumbnailResponse getStoreThumbnail(Long id) {
+        return StoreThumbnailResponse.of(storeFinder.findByIdWhereDeletedIsFalse(id));
+    }
+
     public CategoriesResponse getCategories() {
         return new CategoriesResponse(Arrays.stream(StoreCategory.values())
                 .map(CategoryResponse::of)

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -2,7 +2,13 @@ package org.hankki.hankkiserver.api.store.service.response;
 
 import org.hankki.hankkiserver.domain.store.model.Store;
 
-public record StoreThumbnailResponse(long id, String name, String category, int lowestPrice, int heartCount) {
+public record StoreThumbnailResponse(
+        long id,
+        String name,
+        String category,
+        int lowestPrice,
+        int heartCount
+) {
     public static StoreThumbnailResponse of(Store store) {
         return new StoreThumbnailResponse(
                 store.getId(),

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -1,0 +1,15 @@
+package org.hankki.hankkiserver.api.store.service.response;
+
+import org.hankki.hankkiserver.domain.store.model.Store;
+
+public record StoreThumbnailResponse(long id, String name, String category, int lowestPrice, int heartCount) {
+    public static StoreThumbnailResponse of(Store store) {
+        return new StoreThumbnailResponse(
+                store.getId(),
+                store.getName(),
+                store.getCategory().name(),
+                store.getLowestPrice(),
+                store.getHeartCount()
+        );
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/common/code/StoreErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/StoreErrorCode.java
@@ -1,0 +1,15 @@
+package org.hankki.hankkiserver.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreErrorCode implements ErrorCode {
+
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
@@ -2,6 +2,11 @@ package org.hankki.hankkiserver.domain.store.repository;
 
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    @Query("select s from Store s where s.id = :id and s.isDeleted = false")
+    Optional<Store> findByIdAndIsDeletedIsFalse(Long id);
 }


### PR DESCRIPTION
## Related Issue 📌
close #46 

## Description ✔️
- 식당 썸네일 조회 api입니다.
- 식당의 pk를 받으면 식당의 썸네일 생성에 필요한 정보를 반환합니다.
- soft delete 되지 않은 식당의 정보만 보여줍니다.

## To Reviewers
- soft delete 여부를 쿼리에 작성했습니다.
- 일단 soft delete여부 상관 없이 갖고 온 후, was에서 soft deleted면 exception을 던질까 아니면 쿼리 자체에서 soft deleted된 가게는 갖고오지 않을지 고민중입니다. 의견 주세요