### PR TITLE
[refac] 회원 탈퇴 시 카카오 서버와 연결 끊기

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/auth/controller/AuthController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/auth/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
     public HankkiResponse<Void> withdraw(
             @UserId final Long userId,
             @Nullable @RequestHeader("X-Apple-Code") final String code){
-        authService.withdraw(userId,code);
+        authService.withdraw(userId, code);
         return HankkiResponse.success(CommonSuccessCode.NO_CONTENT);
     }
 

--- a/src/main/java/org/hankki/hankkiserver/domain/user/model/User.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/user/model/User.java
@@ -63,4 +63,8 @@ public class User extends BaseTimeEntity {
     public void updateStatus(MemberStatus memberStatus) {
         this.memberStatus = memberStatus;
     }
+
+    public void updateDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/org/hankki/hankkiserver/external/openfeign/apple/AppleOAuthProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/external/openfeign/apple/AppleOAuthProvider.java
@@ -38,7 +38,7 @@ public class AppleOAuthProvider {
                 claims.get("email").toString());
     }
 
-    public String getAppleToken(final String code) {
+    public String getAppleRefreshToken(final String code) {
         try {
             String clientSecret = appleClientSecretGenerator.generateClientSecret();
             AppleTokenResponse appleTokenResponse = appleFeignClient.getAppleTokens(

--- a/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/KakaoFeignClient.java
+++ b/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/KakaoFeignClient.java
@@ -1,16 +1,23 @@
 package org.hankki.hankkiserver.external.openfeign.kakao;
 
+import org.hankki.hankkiserver.external.openfeign.kakao.dto.KakaoUnlinkRequest;
 import org.hankki.hankkiserver.external.openfeign.kakao.dto.KakaoUserInfo;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.*;
 
-@FeignClient(name = "kakaoClient", url = "https://kapi.kakao.com/v2/user/me")
+@FeignClient(name = "kakaoClient", url = "https://kapi.kakao.com")
 public interface KakaoFeignClient {
 
-    @GetMapping
+    @GetMapping("/v2/user/me")
     KakaoUserInfo getUserInfo(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken
+    );
+
+    @PostMapping("/v1/user/unlink")
+    void unlinkKakaoServer(
+            @RequestHeader("Authorization") String adminKey,
+            @RequestParam(name = "target_id_type") String targetIdType,
+            @RequestParam("target_id") Long targetId
     );
 }

--- a/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/KakaoOAuthProvider.java
@@ -2,6 +2,7 @@ package org.hankki.hankkiserver.external.openfeign.kakao;
 
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.external.openfeign.dto.SocialInfoDto;
+import org.hankki.hankkiserver.external.openfeign.kakao.dto.KakaoUnlinkRequest;
 import org.hankki.hankkiserver.external.openfeign.kakao.dto.KakaoUserInfo;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,8 @@ public class KakaoOAuthProvider {
 
     private final KakaoFeignClient kakaoFeignClient;
 
+    private static final String GRANT_TYPE = "KakaoAK ";
+
     public SocialInfoDto getKakaoUserInfo(final String providerToken) {
         KakaoAccessToken kakaoAccessToken = createKakaoAccessToken(providerToken);
         String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
@@ -21,5 +24,9 @@ public class KakaoOAuthProvider {
                 kakaoUserInfo.id().toString(),
                 kakaoUserInfo.kakaoAccount().kakaoUserProfile().nickname(),
                 kakaoUserInfo.kakaoAccount().email());
+    }
+
+    public void unlinkKakaoServer(final String adminKey, KakaoUnlinkRequest kakaoUnlinkRequest) {
+        kakaoFeignClient.unlinkKakaoServer(GRANT_TYPE + adminKey, kakaoUnlinkRequest.targetIdType(), kakaoUnlinkRequest.targetId());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/dto/KakaoUnlinkRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/external/openfeign/kakao/dto/KakaoUnlinkRequest.java
@@ -1,0 +1,12 @@
+package org.hankki.hankkiserver.external.openfeign.kakao.dto;
+
+public record KakaoUnlinkRequest(
+        String targetIdType,
+        Long targetId
+) {
+    private static final String TARGET_ID_TYPE = "user_id";
+
+    public static KakaoUnlinkRequest of(final String targetId) {
+        return new KakaoUnlinkRequest(TARGET_ID_TYPE, Long.parseLong(targetId));
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
close #48 

## Description ✔️
- 회원 탈퇴할 때 카카오 서버와 연결 끊는 작업 추가했습니다.

## To Reviewers
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink
위의 링크 참고 했습니다