### PR TITLE
[feat] 식당 세부 정보 조회 api 

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuFinder.java
@@ -1,0 +1,20 @@
+package org.hankki.hankkiserver.api.menu.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.menu.model.Menu;
+import org.hankki.hankkiserver.domain.menu.repository.MenuRepository;
+import org.hankki.hankkiserver.domain.store.model.Store;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MenuFinder {
+
+    private final MenuRepository menuRepository;
+
+    public List<Menu> findAllByStore(Store store) {
+        return menuRepository.findAllByStore(store);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -25,6 +25,11 @@ public class StoreController {
     private final StoreQueryService storeQueryService;
     private final HeartCommandService heartCommandService;
 
+    @GetMapping("/stores/{id}")
+    public HankkiResponse<StoreGetResponse> getStore(@PathVariable Long id) {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreInformation(id));
+    }
+
     @GetMapping("/stores/{id}/thumbnail")
     public HankkiResponse<StoreThumbnailResponse> getStoreThumbnail(@PathVariable Long id) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreThumbnail(id));

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -26,12 +26,12 @@ public class StoreController {
     private final HeartCommandService heartCommandService;
 
     @GetMapping("/stores/{id}")
-    public HankkiResponse<StoreGetResponse> getStore(@PathVariable Long id) {
+    public HankkiResponse<StoreGetResponse> getStore(@PathVariable final Long id) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreInformation(id));
     }
 
     @GetMapping("/stores/{id}/thumbnail")
-    public HankkiResponse<StoreThumbnailResponse> getStoreThumbnail(@PathVariable Long id) {
+    public HankkiResponse<StoreThumbnailResponse> getStoreThumbnail(@PathVariable final Long id) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreThumbnail(id));
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -17,12 +17,12 @@ public class StoreFinder {
         return storeRepository.getReferenceById(id);
     }
 
-    protected Store findByIdWhereDeletedIsFalse(Long id) {
+    protected Store findByIdWhereDeletedIsFalse(final Long id) {
         return storeRepository.findByIdAndIsDeletedIsFalse(id)
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    protected Store findByIdWithHeartAndIsDeletedFalse(Long id) {
+    protected Store findByIdWithHeartAndIsDeletedFalse(final Long id) {
         return storeRepository.findByIdWithHeartAndIsDeletedFalse(id)
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -13,12 +13,17 @@ public class StoreFinder {
 
     private final StoreRepository storeRepository;
 
+    public Store getStoreReference(final Long id) {
+        return storeRepository.getReferenceById(id);
+    }
+
     protected Store findByIdWhereDeletedIsFalse(Long id) {
         return storeRepository.findByIdAndIsDeletedIsFalse(id)
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    public Store getStoreReference(final Long id) {
-        return storeRepository.getReferenceById(id);
+    protected Store findStoreByIdWithHeart(Long id) {
+        return storeRepository.findStoreByIdWithHeart(id)
+                .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -22,8 +22,8 @@ public class StoreFinder {
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    protected Store findStoreByIdWithHeart(Long id) {
-        return storeRepository.findStoreByIdWithHeart(id)
+    protected Store findByIdWithHeartAndIsDeletedFalse(Long id) {
+        return storeRepository.findByIdWithHeartAndIsDeletedFalse(id)
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -6,6 +6,7 @@ import org.hankki.hankkiserver.api.menu.service.MenuFinder;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.*;
+import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.store.model.StoreImage;
@@ -67,6 +68,10 @@ public class StoreQueryService {
     }
 
     private boolean isLiked(final Long id, final Store store) {
-        return store.getHearts().stream().anyMatch(heart -> heart.getUser().getId().equals(id));
+        return store.getHearts().stream().anyMatch(heart -> isLiked(id, heart));
+    }
+
+    private static boolean isLiked(final Long id, final Heart heart) {
+        return heart.getUser().getId().equals(id);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -29,7 +29,7 @@ public class StoreQueryService {
     @Transactional(readOnly = true)
     public StoreGetResponse getStoreInformation(Long id) {
 
-        Store store = storeFinder.findStoreByIdWithHeart(id);
+        Store store = storeFinder.findByIdWithHeartAndIsDeletedFalse(id);
 
         return StoreGetResponse.of(store,
                 isLiked(id, store),

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -8,6 +8,7 @@ import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.*;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.domain.store.model.StoreImage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +23,12 @@ public class StoreQueryService {
     private final MenuFinder menuFinder;
 
     @Transactional(readOnly = true)
-    public StoreThumbnailResponse getStoreThumbnail(Long id) {
+    public StoreThumbnailResponse getStoreThumbnail(final Long id) {
         return StoreThumbnailResponse.of(storeFinder.findByIdWhereDeletedIsFalse(id));
     }
 
     @Transactional(readOnly = true)
-    public StoreGetResponse getStoreInformation(Long id) {
+    public StoreGetResponse getStoreInformation(final Long id) {
 
         Store store = storeFinder.findByIdWithHeartAndIsDeletedFalse(id);
 
@@ -55,17 +56,17 @@ public class StoreQueryService {
                 .toList());
     }
 
-    private List<String> getImageUrlsFromStore(Store store) {
+    private List<String> getImageUrlsFromStore(final Store store) {
         return store.getImages().stream()
-                .map(storeImage -> storeImage.getImageUrl())
+                .map(StoreImage::getImageUrl)
                 .toList();
     }
 
-    private List<MenuResponse> getMenus(Store store) {
+    private List<MenuResponse> getMenus(final Store store) {
         return menuFinder.findAllByStore(store).stream().map(MenuResponse::of).toList();
     }
 
-    private boolean isLiked(Long id, Store store) {
+    private boolean isLiked(final Long id, final Store store) {
         return store.getHearts().stream().anyMatch(heart -> heart.getUser().getId().equals(id));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -2,24 +2,39 @@ package org.hankki.hankkiserver.api.store.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.menu.service.MenuFinder;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.*;
+import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StoreQueryService {
 
     private final StoreFinder storeFinder;
+    private final MenuFinder menuFinder;
 
-    @Transactional(readOnly = true)//주어진 pk를 가진 식당의 정보를 조회 이때 식당의 상태가 is_deleted면 404를 나타낸다.
+    @Transactional(readOnly = true)
     public StoreThumbnailResponse getStoreThumbnail(Long id) {
         return StoreThumbnailResponse.of(storeFinder.findByIdWhereDeletedIsFalse(id));
+    }
+
+    @Transactional(readOnly = true)
+    public StoreGetResponse getStoreInformation(Long id) {
+
+        Store store = storeFinder.findStoreByIdWithHeart(id);
+
+        return StoreGetResponse.of(store,
+                isLiked(id, store),
+                getImageUrlsFromStore(store),
+                getMenus(store));
     }
 
     public CategoriesResponse getCategories() {
@@ -38,5 +53,19 @@ public class StoreQueryService {
         return new PriceCategoriesResponse(Arrays.stream(PriceCategory.values())
                 .map(PriceCategoryResponse::of)
                 .toList());
+    }
+
+    private List<String> getImageUrlsFromStore(Store store) {
+        return store.getImages().stream()
+                .map(storeImage -> storeImage.getImageUrl())
+                .toList();
+    }
+
+    private List<MenuResponse> getMenus(Store store) {
+        return menuFinder.findAllByStore(store).stream().map(MenuResponse::of).toList();
+    }
+
+    private boolean isLiked(Long id, Store store) {
+        return store.getHearts().stream().anyMatch(heart -> heart.getUser().getId().equals(id));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/MenuResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/MenuResponse.java
@@ -1,0 +1,12 @@
+package org.hankki.hankkiserver.api.store.service.response;
+
+import org.hankki.hankkiserver.domain.menu.model.Menu;
+
+public record MenuResponse(
+        String name,
+        int price
+) {
+    public static MenuResponse of(Menu menu) {
+        return new MenuResponse(menu.getName(), menu.getPrice());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
@@ -12,14 +12,12 @@ public record StoreGetResponse(
         List<String> imageUrls,
         List<MenuResponse> menus
 ) {
-    public static StoreGetResponse of(Store store, boolean isLiked, List<MenuResponse> menus) {
+    public static StoreGetResponse of(Store store, boolean isLiked, List<String> imageUrls, List<MenuResponse> menus) {
         return new StoreGetResponse(store.getName(),
                 store.getCategory().getName(),
                 store.getHeartCount(),
                 isLiked,
-                store.getImages().stream()
-                        .map(storeImage -> storeImage.getImageUrl())
-                        .toList(),
+                imageUrls,
                 menus);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
@@ -1,0 +1,25 @@
+package org.hankki.hankkiserver.api.store.service.response;
+
+import org.hankki.hankkiserver.domain.store.model.Store;
+
+import java.util.List;
+
+public record StoreGetResponse(
+        String name,
+        String category,
+        int heartCount,
+        boolean isLiked,
+        List<String> imageUrls,
+        List<MenuResponse> menus
+) {
+    public static StoreGetResponse of(Store store, boolean isLiked, List<MenuResponse> menus) {
+        return new StoreGetResponse(store.getName(),
+                store.getCategory().getName(),
+                store.getHeartCount(),
+                isLiked,
+                store.getImages().stream()
+                        .map(storeImage -> storeImage.getImageUrl())
+                        .toList(),
+                menus);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreGetResponse.java
@@ -12,7 +12,7 @@ public record StoreGetResponse(
         List<String> imageUrls,
         List<MenuResponse> menus
 ) {
-    public static StoreGetResponse of(Store store, boolean isLiked, List<String> imageUrls, List<MenuResponse> menus) {
+    public static StoreGetResponse of(final Store store, final boolean isLiked, final List<String> imageUrls, final List<MenuResponse> menus) {
         return new StoreGetResponse(store.getName(),
                 store.getCategory().getName(),
                 store.getHeartCount(),

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -9,7 +9,7 @@ public record StoreThumbnailResponse(
         int lowestPrice,
         int heartCount
 ) {
-    public static StoreThumbnailResponse of(Store store) {
+    public static StoreThumbnailResponse of(final Store store) {
         return new StoreThumbnailResponse(
                 store.getId(),
                 store.getName(),

--- a/src/main/java/org/hankki/hankkiserver/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/menu/repository/MenuRepository.java
@@ -1,7 +1,11 @@
 package org.hankki.hankkiserver.domain.menu.repository;
 
 import org.hankki.hankkiserver.domain.menu.model.Menu;
+import org.hankki.hankkiserver.domain.store.model.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findAllByStore(Store store);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hankki.hankkiserver.domain.common.BaseTimeEntity;
 import org.hankki.hankkiserver.domain.common.Point;
+import org.hankki.hankkiserver.domain.heart.model.Heart;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,6 +19,12 @@ public class Store extends BaseTimeEntity {
     @Column(name = "store_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "store")
+    private List<Heart> hearts;
+
+    @OneToMany(mappedBy = "store")
+    private List<StoreImage> images;
 
     @Embedded
     private Point point;

--- a/src/main/java/org/hankki/hankkiserver/domain/store/model/StoreImage.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/model/StoreImage.java
@@ -21,6 +21,6 @@ public class StoreImage extends BaseCreatedAtEntity {
     private Store store;
 
     @Column(nullable = false)
-    private String image_url;
+    private String imageUrl;
 
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
@@ -11,5 +11,5 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByIdAndIsDeletedIsFalse(Long id);
 
     @Query("select s from Store s join fetch s.hearts where s.id = :id and s.isDeleted = false")
-    Optional<Store> findStoreByIdWithHeart(Long id);
+    Optional<Store> findByIdWithHeartAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
@@ -9,4 +9,7 @@ import java.util.Optional;
 public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("select s from Store s where s.id = :id and s.isDeleted = false")
     Optional<Store> findByIdAndIsDeletedIsFalse(Long id);
+
+    @Query("select s from Store s join fetch s.hearts where s.id = :id and s.isDeleted = false")
+    Optional<Store> findStoreByIdWithHeart(Long id);
 }


### PR DESCRIPTION
## Related Issue 📌
close #50 
## Description ✔️

- <img width="326" alt="스크린샷 2024-07-12 오전 10 08 01" src="https://github.com/user-attachments/assets/94cbb451-d8d8-484e-acfd-42f0f7ddc4dc">

- <img width="332" alt="스크린샷 2024-07-12 오전 10 09 11" src="https://github.com/user-attachments/assets/e54fa0a4-4b62-42f0-9afa-447c71efcbf7">

## To Reviewers
- 기존에는 jpql을 사용하여 dto로 바로 받아오려 했지만..
현재 응답 구조가 dto안에 dto가 있는 구조여서 dto로 받아오지 못했습니다..(되나 안 되나 앱잼 이후 확인 필요)
그래서 
store, heart(일대다)를 fetch join하여 가져 온 후 식당정보, 좋아요 여부에 대한 정보 추출,
menu table 조회 후 메뉴 응답 리스트 생성,
storeImage를 조회하여 사진 리스트 생성하여 반환했습니다.
@Batch를 사용할까 하기도 했지만.. 어차피 같은 수의 쿼리가 나가게 되어 현재 로직으로 결정했습니다.

+ dto 생성 메서드에 관한 의견이 궁금합니다.. dto에서 변환 로직을 빼고 싶어서 현재 4개의 매개변수를 사용하는데.. 개선할 방법이 있을까요?