### PR TITLE
[feat] 사용자가 좋아요를 한 가게들의 정보들을 불러오는 api

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
@@ -1,10 +1,13 @@
 package org.hankki.hankkiserver.api.store.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.hankki.hankkiserver.domain.heart.repository.HeartRepository;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
@@ -17,6 +17,6 @@ public class HeartFinder {
     }
 
     public List<Heart> findHeartedStoresByUserId(final Long userId) {
-        return heartRepository.findHeartedStoresByUserId(userId);
+        return heartRepository.findAllWithStoreByUserId(userId);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartFinder.java
@@ -15,4 +15,8 @@ public class HeartFinder {
     public boolean existsByUserAndStore(final User user, final Store store) {
         return heartRepository.existsByUserAndStore(user, store);
     }
+
+    public List<Heart> findHeartedStoresByUserId(final Long userId) {
+        return heartRepository.findHeartedStoresByUserId(userId);
+    }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
@@ -8,6 +8,7 @@ import org.hankki.hankkiserver.api.user.service.UserCommandService;
 import org.hankki.hankkiserver.api.user.service.UserQueryService;
 import org.hankki.hankkiserver.api.user.service.command.UserUniversityPostCommand;
 import org.hankki.hankkiserver.api.user.service.response.UserFavoritesGetResponse;
+import org.hankki.hankkiserver.api.user.service.response.UserHeartedStoreListResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
 import org.hankki.hankkiserver.auth.UserId;
@@ -42,5 +43,10 @@ public class UserController {
     @GetMapping("/users/me/favorites")
     public HankkiResponse<UserFavoritesGetResponse> findUserFavorites(@UserId final Long userId) {
         return HankkiResponse.success(CommonSuccessCode.OK, userQueryService.findUserFavorites(userId));
+    }
+
+    @GetMapping("/users/me/stores/hearts")
+    public HankkiResponse<UserHeartedStoreListResponse> getUserHeartedStores(@UserId final Long userId) {
+        return HankkiResponse.success(CommonSuccessCode.OK, userQueryService.findUserHeartedStoresView(userId));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -5,16 +5,13 @@ import org.hankki.hankkiserver.api.auth.service.UserInfoFinder;
 import org.hankki.hankkiserver.api.favorite.service.FavoriteFinder;
 import org.hankki.hankkiserver.api.store.service.HeartFinder;
 import org.hankki.hankkiserver.api.user.service.response.UserFavoritesGetResponse;
-import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserHeartedStoreListResponse;
+import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
 import org.hankki.hankkiserver.common.code.UserUniversityErrorCode;
 import org.hankki.hankkiserver.common.exception.NotFoundException;
-import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +40,6 @@ public class UserQueryService {
 
     @Transactional(readOnly = true)
     public UserHeartedStoreListResponse findUserHeartedStoresView(final Long userId) {
-        List<Heart> hearts = heartFinder.findHeartedStoresByUserId(userId);
-        return UserHeartedStoreListResponse.of(hearts);
+        return UserHeartedStoreListResponse.of(heartFinder.findHeartedStoresByUserId(userId));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -6,11 +6,15 @@ import org.hankki.hankkiserver.api.favorite.service.FavoriteFinder;
 import org.hankki.hankkiserver.api.store.service.HeartFinder;
 import org.hankki.hankkiserver.api.user.service.response.UserFavoritesGetResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
+import org.hankki.hankkiserver.api.user.service.response.UserHeartedStoreListResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
 import org.hankki.hankkiserver.common.code.UserUniversityErrorCode;
 import org.hankki.hankkiserver.common.exception.NotFoundException;
+import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +39,11 @@ public class UserQueryService {
     @Transactional(readOnly = true)
     public UserProfileAndNicknameResponse getUserProfileAndNickname(final Long userId) {
         return UserProfileAndNicknameResponse.of(userInfoFinder.getUserInfo(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public UserHeartedStoreListResponse findUserHeartedStoresView(final Long userId) {
+        List<Heart> hearts = heartFinder.findHeartedStoresByUserId(userId);
+        return UserHeartedStoreListResponse.of(hearts);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreListResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreListResponse.java
@@ -1,0 +1,14 @@
+package org.hankki.hankkiserver.api.user.service.response;
+
+import org.hankki.hankkiserver.domain.heart.model.Heart;
+
+import java.util.List;
+
+public record UserHeartedStoreListResponse(
+        List<UserHeartedStoreViewResponse> stores
+) {
+    public static UserHeartedStoreListResponse of(List<Heart> hearts) {
+        return new UserHeartedStoreListResponse(hearts.stream()
+                .map(UserHeartedStoreViewResponse::of).toList());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreListResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreListResponse.java
@@ -9,6 +9,7 @@ public record UserHeartedStoreListResponse(
 ) {
     public static UserHeartedStoreListResponse of(List<Heart> hearts) {
         return new UserHeartedStoreListResponse(hearts.stream()
-                .map(UserHeartedStoreViewResponse::of).toList());
+                .map(heart -> UserHeartedStoreViewResponse.of(heart.getStore()))
+                .toList());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
@@ -1,6 +1,6 @@
 package org.hankki.hankkiserver.api.user.service.response;
 
-import org.hankki.hankkiserver.domain.heart.model.Heart;
+import org.hankki.hankkiserver.domain.store.model.Store;
 
 public record UserHeartedStoreViewResponse(
         Long id,
@@ -10,14 +10,14 @@ public record UserHeartedStoreViewResponse(
         int lowestPrice,
         int heartCount
 ) {
-    public static UserHeartedStoreViewResponse of(Heart heart) {
+    public static UserHeartedStoreViewResponse of(Store store) {
         return new UserHeartedStoreViewResponse(
-                heart.getStore().getId(),
-                heart.getStore().getName(),
-                heart.getStore().getImage(),
-                heart.getStore().getCategory().getName(),
-                heart.getStore().getLowestPrice(),
-                heart.getStore().getHeartCount()
+                store.getId(),
+                store.getName(),
+                store.getImage(),
+                store.getCategory().getName(),
+                store.getLowestPrice(),
+                store.getHeartCount()
         );
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
@@ -14,7 +14,7 @@ public record UserHeartedStoreViewResponse(
         return new UserHeartedStoreViewResponse(
                 store.getId(),
                 store.getName(),
-                store.getImage(),
+                store.getImages().get(0).getImageUrl(),
                 store.getCategory().getName(),
                 store.getLowestPrice(),
                 store.getHeartCount()

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserHeartedStoreViewResponse.java
@@ -1,0 +1,23 @@
+package org.hankki.hankkiserver.api.user.service.response;
+
+import org.hankki.hankkiserver.domain.heart.model.Heart;
+
+public record UserHeartedStoreViewResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        String category,
+        int lowestPrice,
+        int heartCount
+) {
+    public static UserHeartedStoreViewResponse of(Heart heart) {
+        return new UserHeartedStoreViewResponse(
+                heart.getStore().getId(),
+                heart.getStore().getName(),
+                heart.getStore().getImage(),
+                heart.getStore().getCategory().getName(),
+                heart.getStore().getLowestPrice(),
+                heart.getStore().getHeartCount()
+        );
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -4,9 +4,16 @@ import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     boolean existsByUserAndStore(User user, Store store);
     void deleteByUserAndStore(User user, Store store);
+
+    @Query("select h from Heart h join fetch h.store s join fetch s.storeImages " +
+            "where h.user.id = :userId and s.isDeleted = false order by h.id desc")
+    List<Heart> findHeartedStoresByUserId(Long userId);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -15,5 +15,5 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     @Query("select h from Heart h join fetch h.store s join fetch s.images " +
             "where h.user.id = :userId and s.isDeleted = false order by h.id desc")
-    List<Heart> findHeartedStoresByUserId(Long userId);
+    List<Heart> findAllWithStoreByUserId(Long userId);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -13,7 +13,7 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsByUserAndStore(User user, Store store);
     void deleteByUserAndStore(User user, Store store);
 
-    @Query("select h from Heart h join fetch h.store s join fetch s.storeImages " +
+    @Query("select h from Heart h join fetch h.store s join fetch s.images " +
             "where h.user.id = :userId and s.isDeleted = false order by h.id desc")
     List<Heart> findHeartedStoresByUserId(Long userId);
 }


### PR DESCRIPTION
## Related Issue 📌
close #60 

## Description ✔️
- 사용자가 좋아요한 가게의 정보들을 불러오는 api 입니다.

## To Reviewers
일단 fetch join으로 구현해보았는데, fetch join을 안써도 되는지 좀 더 고민해보겠습니다.
+ 정렬은 디자인 측에서 좋아요가 가장 최신에 추가된 가게가 맨 상단에 있었으면 좋겠다고 하여 기본키 값을 내림차순으로 정렬하였습니다.

#### 응답 결과
<img width="360" alt="image" src="https://github.com/user-attachments/assets/32c6a008-3283-4b9b-82a0-c03f67716a93">

#### 쿼리문
```
Hibernate: 
    select
        h1_0.heart_id,
        s1_0.store_id,
        s1_0.category,
        s1_0.created_at,
        s1_0.heart_count,
        i1_0.store_id,
        i1_0.store_image_id,
        i1_0.created_at,
        i1_0.image_url,
        s1_0.is_deleted,
        s1_0.lowest_price,
        s1_0.name,
        s1_0.latitude,
        s1_0.longitude,
        s1_0.updated_at,
        h1_0.user_id 
    from
        heart h1_0 
    join
        store s1_0 
            on s1_0.store_id=h1_0.store_id 
    join
        store_image i1_0 
            on s1_0.store_id=i1_0.store_id 
    where
        h1_0.user_id=? 
        and s1_0.is_deleted=false 
    order by
        h1_0.heart_id desc
```