### PR TITLE
[feat] 좋아요 전체 갯수 응답값 추가

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
@@ -31,7 +31,7 @@ public class HeartCommandService {
         validateStoreHeartCreation(user, store);
         saveStoreHeart(user, store);
         increaseStoreHeartCount(store);
-        return HeartCreateResponse.of(store.getId(), true, findTotalHeartCount(store));
+        return HeartCreateResponse.of(store);
     }
 
     public HeartDeleteResponse deleteHeart(final StoreDeleteCommand storeDeleteCommand) {
@@ -40,7 +40,7 @@ public class HeartCommandService {
         validateStoreHeartRemoval(user, store);
         heartDeleter.deleteHeart(user,store);
         decreaseStoreHeartCount(store);
-        return HeartDeleteResponse.of(store.getId(), false, findTotalHeartCount(store));
+        return HeartDeleteResponse.of(store);
     }
 
     private void validateStoreHeartCreation(final User user, final Store store) {
@@ -65,9 +65,5 @@ public class HeartCommandService {
 
     private void decreaseStoreHeartCount(final Store store) {
         store.decreaseHeartCount();
-    }
-
-    private int findTotalHeartCount(final Store store) {
-        return store.getHeartCount();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
@@ -31,7 +31,7 @@ public class HeartCommandService {
         validateStoreHeartCreation(user, store);
         saveStoreHeart(user, store);
         increaseStoreHeartCount(store);
-        return HeartCreateResponse.of(store.getId(), true);
+        return HeartCreateResponse.of(store.getId(), true, findTotalHeartCount(store));
     }
 
     public HeartDeleteResponse deleteHeart(final StoreDeleteCommand storeDeleteCommand) {
@@ -40,7 +40,7 @@ public class HeartCommandService {
         validateStoreHeartRemoval(user, store);
         heartDeleter.deleteHeart(user,store);
         decreaseStoreHeartCount(store);
-        return HeartDeleteResponse.of(store.getId(), false);
+        return HeartDeleteResponse.of(store.getId(), false, findTotalHeartCount(store));
     }
 
     private void validateStoreHeartCreation(final User user, final Store store) {
@@ -65,5 +65,9 @@ public class HeartCommandService {
 
     private void decreaseStoreHeartCount(final Store store) {
         store.decreaseHeartCount();
+    }
+
+    private int findTotalHeartCount(final Store store) {
+        return store.getHeartCount();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartCreateResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartCreateResponse.java
@@ -1,11 +1,13 @@
 package org.hankki.hankkiserver.api.store.service.response;
 
+import org.hankki.hankkiserver.domain.store.model.Store;
+
 public record HeartCreateResponse(
         Long storeId,
-        boolean isHearted,
-        int count
+        int count,
+        boolean isHearted
 ) {
-    public static HeartCreateResponse of(final Long storeId, final boolean isHearted, final int count) {
-        return new HeartCreateResponse(storeId, isHearted, count);
+    public static HeartCreateResponse of(final Store store) {
+        return new HeartCreateResponse(store.getId(), store.getHeartCount(), true);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartCreateResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartCreateResponse.java
@@ -2,9 +2,10 @@ package org.hankki.hankkiserver.api.store.service.response;
 
 public record HeartCreateResponse(
         Long storeId,
-        boolean isHearted
+        boolean isHearted,
+        int count
 ) {
-    public static HeartCreateResponse of(final Long storeId, final boolean isHearted) {
-        return new HeartCreateResponse(storeId, isHearted);
+    public static HeartCreateResponse of(final Long storeId, final boolean isHearted, final int count) {
+        return new HeartCreateResponse(storeId, isHearted, count);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartDeleteResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartDeleteResponse.java
@@ -2,9 +2,10 @@ package org.hankki.hankkiserver.api.store.service.response;
 
 public record HeartDeleteResponse(
         Long storeId,
-        boolean isHearted
+        boolean isHearted,
+        int count
 ) {
-    public static HeartDeleteResponse of(final Long storeId, final boolean isHearted) {
-        return new HeartDeleteResponse(storeId, isHearted);
+    public static HeartDeleteResponse of(final Long storeId, final boolean isHearted, final int count) {
+        return new HeartDeleteResponse(storeId, isHearted, count);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartDeleteResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/HeartDeleteResponse.java
@@ -1,11 +1,13 @@
 package org.hankki.hankkiserver.api.store.service.response;
 
+import org.hankki.hankkiserver.domain.store.model.Store;
+
 public record HeartDeleteResponse(
         Long storeId,
-        boolean isHearted,
-        int count
+        int count,
+        boolean isHearted
 ) {
-    public static HeartDeleteResponse of(final Long storeId, final boolean isHearted, final int count) {
-        return new HeartDeleteResponse(storeId, isHearted, count);
+    public static HeartDeleteResponse of(final Store store) {
+        return new HeartDeleteResponse(store.getId(), store.getHeartCount(), false);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -5,8 +5,6 @@ import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     boolean existsByUserAndStore(User user, Store store);


### PR DESCRIPTION
## Related Issue 📌
close #82 

## Description ✔️
- 좋아요 취소와 생성을 요청을 보낼 때, 그 응답값으로 해당 가게의 전체 좋아요 갯수도 함께 보내달라는 클라측의 요청이 있어 이를 반영하였습니다.

## To Reviewers
### 응답 결과
<img width="295" alt="image" src="https://github.com/user-attachments/assets/105507c6-3f87-4b86-91ab-5ea84e7bdd6b">

<img width="293" alt="image" src="https://github.com/user-attachments/assets/0dc3a7ef-9b6c-4ca3-b7b6-d3d284723caa">

