### PR TITLE
[feat] 마이페이지 - 사용자가 제보한 가게 API

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/report/service/ReportFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/report/service/ReportFinder.java
@@ -17,6 +17,6 @@ public class ReportFinder {
     }
 
     public List<Report> findAllByUserId(final Long userId) {
-        return reportRepository.findAllByUserIdWithStore(userId);
+        return reportRepository.findAllByUserIdWithStoreAndStoreImage(userId);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/report/service/ReportFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/report/service/ReportFinder.java
@@ -1,9 +1,10 @@
 package org.hankki.hankkiserver.api.report.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.domain.report.model.Report;
 import org.hankki.hankkiserver.domain.report.repository.ReportRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,5 +14,9 @@ public class ReportFinder {
 
     public long getReportCount() {
         return reportRepository.count();
+    }
+
+    public List<Report> findAllByUserId(final Long userId) {
+        return reportRepository.findAllByUserIdWithStore(userId);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/UserController.java
@@ -10,6 +10,7 @@ import org.hankki.hankkiserver.api.user.service.command.UserUniversityPostComman
 import org.hankki.hankkiserver.api.user.service.response.UserFavoritesGetResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserHeartedStoreListResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
+import org.hankki.hankkiserver.api.user.service.response.UserStoresReportedGetResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
 import org.hankki.hankkiserver.auth.UserId;
 import org.hankki.hankkiserver.common.code.CommonSuccessCode;
@@ -48,5 +49,10 @@ public class UserController {
     @GetMapping("/users/me/stores/hearts")
     public HankkiResponse<UserHeartedStoreListResponse> getUserHeartedStores(@UserId final Long userId) {
         return HankkiResponse.success(CommonSuccessCode.OK, userQueryService.findUserHeartedStoresView(userId));
+    }
+
+    @GetMapping("/users/me/stores/reports")
+    public HankkiResponse<UserStoresReportedGetResponse> findUserStoreReported(@UserId final Long userId) {
+        return HankkiResponse.success(CommonSuccessCode.OK, userQueryService.findUserStoreReported(userId));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -7,9 +7,12 @@ import org.hankki.hankkiserver.api.store.service.HeartFinder;
 import org.hankki.hankkiserver.api.user.service.response.UserFavoritesGetResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserHeartedStoreListResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserProfileAndNicknameResponse;
+import org.hankki.hankkiserver.api.report.service.ReportFinder;
+import org.hankki.hankkiserver.api.user.service.response.UserStoresReportedGetResponse;
 import org.hankki.hankkiserver.api.user.service.response.UserUniversityFindResponse;
 import org.hankki.hankkiserver.common.code.UserUniversityErrorCode;
 import org.hankki.hankkiserver.common.exception.NotFoundException;
+import org.hankki.hankkiserver.domain.report.model.Report;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +24,7 @@ public class UserQueryService {
     private final FavoriteFinder favoriteFinder;
     private final UserInfoFinder userInfoFinder;
     private final HeartFinder heartFinder;
+    private final ReportFinder reportFinder;
 
     @Transactional(readOnly = true)
     public UserUniversityFindResponse findUserUniversity(Long userId) {
@@ -41,5 +45,9 @@ public class UserQueryService {
     @Transactional(readOnly = true)
     public UserHeartedStoreListResponse findUserHeartedStoresView(final Long userId) {
         return UserHeartedStoreListResponse.of(heartFinder.findHeartedStoresByUserId(userId));
+    }
+
+    public UserStoresReportedGetResponse findUserStoreReported(final Long userId) {
+        return UserStoresReportedGetResponse.of(reportFinder.findAllByUserId(userId).stream().map(Report::getStore).toList());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -47,6 +47,7 @@ public class UserQueryService {
         return UserHeartedStoreListResponse.of(heartFinder.findHeartedStoresByUserId(userId));
     }
 
+    @Transactional(readOnly = true)
     public UserStoresReportedGetResponse findUserStoreReported(final Long userId) {
         return UserStoresReportedGetResponse.of(reportFinder.findAllByUserId(userId).stream().map(Report::getStore).distinct().toList());
     }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/UserQueryService.java
@@ -48,6 +48,6 @@ public class UserQueryService {
     }
 
     public UserStoresReportedGetResponse findUserStoreReported(final Long userId) {
-        return UserStoresReportedGetResponse.of(reportFinder.findAllByUserId(userId).stream().map(Report::getStore).toList());
+        return UserStoresReportedGetResponse.of(reportFinder.findAllByUserId(userId).stream().map(Report::getStore).distinct().toList());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoreReportedResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoreReportedResponse.java
@@ -1,0 +1,20 @@
+package org.hankki.hankkiserver.api.user.service.response;
+
+import org.hankki.hankkiserver.domain.store.model.Store;
+
+public record UserStoreReportedResponse(
+  Long id,
+  String name,
+  String imageUrl,
+  int lowestPrice,
+  int heartCount
+) {
+  public static UserStoreReportedResponse of(Store store) {
+    return new UserStoreReportedResponse(
+        store.getId(),
+        store.getName(),
+        store.getImage(),
+        store.getLowestPrice(),
+        store.getHeartCount());
+  }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoreReportedResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoreReportedResponse.java
@@ -5,6 +5,7 @@ import org.hankki.hankkiserver.domain.store.model.Store;
 public record UserStoreReportedResponse(
   Long id,
   String name,
+  String category,
   String imageUrl,
   int lowestPrice,
   int heartCount
@@ -13,6 +14,7 @@ public record UserStoreReportedResponse(
     return new UserStoreReportedResponse(
         store.getId(),
         store.getName(),
+        store.getCategory().getName(),
         store.getImage(),
         store.getLowestPrice(),
         store.getHeartCount());

--- a/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoresReportedGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/service/response/UserStoresReportedGetResponse.java
@@ -1,0 +1,12 @@
+package org.hankki.hankkiserver.api.user.service.response;
+
+import java.util.List;
+import org.hankki.hankkiserver.domain.store.model.Store;
+
+public record UserStoresReportedGetResponse(
+    List<UserStoreReportedResponse> stores
+) {
+  public static UserStoresReportedGetResponse of(List<Store> stores) {
+    return new UserStoresReportedGetResponse(stores.stream().map(UserStoreReportedResponse::of).toList());
+  }
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
@@ -1,7 +1,13 @@
 package org.hankki.hankkiserver.domain.report.repository;
 
+import java.util.List;
 import org.hankki.hankkiserver.domain.report.model.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+  @Query("select r from Report r join fetch r.store where r.user.id = :userId and r.store.isDeleted = false")
+  List<Report> findAllByUserIdWithStore(@Param("userId") Long userId);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-  @Query("select r from Report r join fetch r.store join fetch r.store.images where r.user.id = :userId and r.store.isDeleted = false")
-  List<Report> findAllByUserIdWithStore(@Param("userId") Long userId);
+  @Query("select r from Report r join fetch r.store join fetch r.store.images where r.user.id = :userId and r.store.isDeleted = false order by r.createdAt desc")
+  List<Report> findAllByUserIdWithStoreAndStoreImage(@Param("userId") Long userId);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/report/repository/ReportRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-  @Query("select r from Report r join fetch r.store where r.user.id = :userId and r.store.isDeleted = false")
+  @Query("select r from Report r join fetch r.store join fetch r.store.images where r.user.id = :userId and r.store.isDeleted = false")
   List<Report> findAllByUserIdWithStore(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## Related Issue 📌
close #59 

## Description ✔️
- 마이페이지 - 사용자가 제보한 가게 API입니다.

## To Reviewers

###작성한 JPQL

사용자의 report를 FK값 userId로 찾고, 연관된 store와 storeImage를 fetch join으로 가져왔습니다. 정렬은 생성일 내림차순으로 했습니다. 
```java
  @Query("select r from Report r join fetch r.store join fetch r.store.images where r.user.id = :userId and r.store.isDeleted = false order by r.createdAt desc")
  List<Report> findAllByUserIdWithStoreAndStoreImage(@Param("userId") Long userId);
```
### service

유저가 서로 다른 대학에 같은 가게를 제보했을 경우 가게가 중복으로 나오기 때문에 distinct()를 통해 중복제거를 해주었습니다. 

```java
    @Transactional(readOnly = true)
    public UserStoresReportedGetResponse findUserStoreReported(final Long userId) {
        return UserStoresReportedGetResponse.of(reportFinder.findAllByUserId(userId).stream().map(Report::getStore).distinct().toList());
    }
```

### 실행쿼리

```sql
Hibernate: 
    select
        r1_0.report_id,
        r1_0.created_at,
        s1_0.store_id,
        s1_0.category,
        s1_0.created_at,
        s1_0.heart_count,
        i1_0.store_id,
        i1_0.store_image_id,
        i1_0.created_at,
        i1_0.image_url,
        s1_0.is_deleted,
        s1_0.lowest_price,
        s1_0.name,
        s1_0.latitude,
        s1_0.longitude,
        s1_0.updated_at,
        r1_0.university_id,
        r1_0.user_id 
    from
        report r1_0 
    join
        store s1_0 
            on s1_0.store_id=r1_0.store_id 
    join
        store_image i1_0 
            on s1_0.store_id=i1_0.store_id 
    where
        r1_0.user_id=? 
        and s1_0.is_deleted=false
```
