### PR TITLE
[fix] 가격정보 드롭다운 조회 응답 변경

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/parameter/PriceCategory.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/parameter/PriceCategory.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum PriceCategory {
 
     K6("6000원 이하", "6000"),
-    k8("6000~8000", "8000");
+    k8("6000~8000원", "8000");
 
     private final String name;
     private final String maxPrice;


### PR DESCRIPTION
## Related Issue 📌
close #86 

## Description ✔️
- 주어진 명세와 같이 가격 뒤에 '원'을 추가했습니다.

## To Reviewers
