### PR TITLE
[fix] 사용자 대학교 설정 정보 조회 API valid 제거 

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/user/controller/request/UserUniversityPostRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/api/user/controller/request/UserUniversityPostRequest.java
@@ -3,5 +3,5 @@ package org.hankki.hankkiserver.api.user.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record UserUniversityPostRequest(long universityId, @NotBlank @Size(max = 5) String name, double longitude, double latitude) {
+public record UserUniversityPostRequest(long universityId, @NotBlank String name, double longitude, double latitude) {
 }


### PR DESCRIPTION
## Related Issue 📌
close #103 

## Description ✔️
- 사용자 대학교 설정 정보 조회 API valid 제거 

## To Reviewers
5자 초과 대학교는 안 들어가서 제거하였습니다. 
