### PR TITLE
[feat] 식당 세부 조회 시 좋아요 테이블 없는 경우 404 나오는 에러 수정

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -21,9 +21,10 @@ public class StoreController {
     private final StoreQueryService storeQueryService;
     private final HeartCommandService heartCommandService;
 
-    @GetMapping("/stores/{id}")
-    public HankkiResponse<StoreGetResponse> getStore(@PathVariable final Long id) {
-        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreInformation(id));
+    @GetMapping("/stores/{storeId}")
+    public HankkiResponse<StoreGetResponse> getStore(@PathVariable final Long storeId,
+                                                     @UserId final Long userId) {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreInformation(storeId, userId));
     }
 
     @GetMapping("/stores/{id}/thumbnail")

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -34,12 +34,12 @@ public class StoreQueryService {
     }
 
     @Transactional(readOnly = true)
-    public StoreGetResponse getStoreInformation(final Long id) {
+    public StoreGetResponse getStoreInformation(final Long storeId, final Long userId) {
 
-        Store store = storeFinder.findByIdWithHeartAndIsDeletedFalse(id);
+        Store store = storeFinder.findByIdWithHeartAndIsDeletedFalse(storeId);
 
         return StoreGetResponse.of(store,
-                isLiked(id, store),
+                isLiked(userId, store),
                 getImageUrlsFromStore(store),
                 getMenus(store));
     }
@@ -72,11 +72,11 @@ public class StoreQueryService {
         return menuFinder.findAllByStore(store).stream().map(MenuResponse::of).toList();
     }
 
-    private boolean isLiked(final Long id, final Store store) {
-        return store.getHearts().stream().anyMatch(heart -> isLiked(id, heart));
+    private boolean isLiked(final Long userId, final Store store) {
+        return store.getHearts().stream().anyMatch(heart -> hasSameUserId(userId, heart));
     }
 
-    private static boolean isLiked(final Long id, final Heart heart) {
+    private boolean hasSameUserId(final Long id, final Heart heart) {
         return heart.getUser().getId().equals(id);
     }
 

--- a/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
@@ -24,7 +24,7 @@ public class Store extends BaseTimeEntity {
     private Long id;
 
     @OneToMany(mappedBy = "store")
-    private List<Heart> hearts;
+    private List<Heart> hearts = new ArrayList<>();
 
     @Embedded
     private Point point;

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
@@ -10,7 +10,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("select s from Store s where s.id = :id and s.isDeleted = false")
     Optional<Store> findByIdAndIsDeletedIsFalse(Long id);
 
-    @Query("select s from Store s join fetch s.hearts where s.id = :id and s.isDeleted = false")
+    @Query("select distinct s from Store s left join fetch s.hearts where s.id = :id and s.isDeleted = false")
     Optional<Store> findByIdWithHeartAndIsDeletedFalse(Long id);
 
     @Query("select s from Store s where s.point.latitude = :latitude and s.point.longitude = :longitude")


### PR DESCRIPTION
## Related Issue 📌
close #88 

## Description ✔️
- 기존에 left join을 하지 않아 식당 조회시 좋아요 중간테이블이 없는 경우 조회가 되지 않았습니다.
- join -> left join을 하여 중간 테이블이 없어도 조회되도록 변경
- isLiked 구하는 로직을 변경하여 userId를 사용하여 좋아요 여부를 찾도록 했습니다.


## To Reviewers
