### PR TITLE
[fix] 썸네일 조회시 이미지 url을 반환하도록 수정

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -7,7 +7,8 @@ public record StoreThumbnailResponse(
         String name,
         String category,
         int lowestPrice,
-        int heartCount
+        int heartCount,
+        String imageUrl
 ) {
     public static StoreThumbnailResponse of(final Store store) {
         return new StoreThumbnailResponse(
@@ -15,7 +16,8 @@ public record StoreThumbnailResponse(
                 store.getName(),
                 store.getCategory().getName(),
                 store.getLowestPrice(),
-                store.getHeartCount()
+                store.getHeartCount(),
+                store.getImages().get(0).getImageUrl()
         );
     }
 }


### PR DESCRIPTION
## Related Issue 📌
close #120 
## Description ✔️
- 썸네일 조회시 이미지 url을 반환하도록 수정

## To Reviewers
- 컬렉션 페치조인(식당, 식당사진)을 하는 비용이나 단일 조회 쿼리 2방 날리는 비용이나 비슷할 거 같아서 굳이 컬렉션 fetch join을 하지는 않았습니다.