### PR TITLE
[fix] 프로필 이미지 변경 이슈 수정

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/auth/service/AuthService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/auth/service/AuthService.java
@@ -109,13 +109,7 @@ public class AuthService {
 
     private User loadOrCreateUser(final Platform platform, final SocialInfoDto socialInfo, final boolean isRegistered) {
         return userFinder.findUserByPlatFormAndSeralId(platform, socialInfo.serialId())
-                .map(user -> {
-                    if (isRegistered) {
-                        return user;
-                    } else {
-                        return updateUserInfo(user);
-                    }
-                })
+                .map(user -> updateOrFindUserInfo(user, isRegistered))
                 .orElseGet(() -> {
                     User newUser = createUser(
                             socialInfo.name(),
@@ -125,6 +119,14 @@ public class AuthService {
                     saveUserAndUserInfo(newUser);
                     return newUser;
                 });
+    }
+
+    private User updateOrFindUserInfo(final User user, final boolean isRegistered) {
+        if (isRegistered) {
+            return user;
+        } else {
+            return updateUserInfo(user);
+        }
     }
 
     private User updateUserInfo(final User user) {


### PR DESCRIPTION
## Related Issue 📌
close #139 

## Description ✔️
- 프로필 이미지가 로그인할 때마다 변경되는 이슈가 있습니다.

## To Reviewers
`loadOrCreateUser` 함수부분에서 탈퇴 후 재가입한 사람인지 로그아웃 후 재가입한 사람인지 구분하지 않고 map 안의 `updateUserInfo`함수가 항상 실행되어 로그인 할 때마다 프로필 이미지가 변경되었던 것 같습니다.
-> isRegistered를 추가적으로 함수 인자로 받아서 False일 경우 탈퇴 후 재가입한 사람, True일 경우 로그아웃한 사람으로 구분하여 함수를 나누었습니다.