### PR TITLE
[refac] 좋아요 로직 예외처리 추가

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/auth/service/UserFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/auth/service/UserFinder.java
@@ -28,14 +28,14 @@ public class UserFinder {
         return userRepository.getReferenceById(id);
     }
 
-    public boolean isRegisteredUser(final Platform platform, final SocialInfoDto socialInfo) {
+    protected boolean isRegisteredUser(final Platform platform, final SocialInfoDto socialInfo) {
         return userRepository.existsByPlatformAndSerialIdAndStatus(
                 platform,
                 socialInfo.serialId(),
                 ACTIVE);
     }
 
-    public Optional<User> findUserByPlatFormAndSeralId(final Platform platform, final String serialId) {
+    protected Optional<User> findUserByPlatFormAndSeralId(final Platform platform, final String serialId) {
         return userRepository.findByPlatformAndSerialId(platform, serialId);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
@@ -27,7 +27,7 @@ public class HeartCommandService {
 
     public HeartCreateResponse createHeart(final HeartPostCommand heartPostCommand) {
         User user = userFinder.getUserReference(heartPostCommand.userId());
-        Store store = storeFinder.getStoreReference(heartPostCommand.storeId());
+        Store store = storeFinder.findByIdWhereDeletedIsFalse(heartPostCommand.storeId());
         validateStoreHeartCreation(user, store);
         saveStoreHeart(user, store);
         increaseStoreHeartCount(store);
@@ -36,7 +36,7 @@ public class HeartCommandService {
 
     public HeartDeleteResponse deleteHeart(final HeartDeleteCommand heartDeleteCommand) {
         User user = userFinder.getUserReference(heartDeleteCommand.userId());
-        Store store = storeFinder.getStoreReference(heartDeleteCommand.storeId());
+        Store store = storeFinder.findByIdWhereDeletedIsFalse(heartDeleteCommand.storeId());
         validateStoreHeartRemoval(user, store);
         heartDeleter.deleteHeart(user,store);
         decreaseStoreHeartCount(store);

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartCommandService.java
@@ -30,7 +30,7 @@ public class HeartCommandService {
         Store store = storeFinder.findByIdWhereDeletedIsFalse(heartPostCommand.storeId());
         validateStoreHeartCreation(user, store);
         saveStoreHeart(user, store);
-        increaseStoreHeartCount(store);
+        store.increaseHeartCount();
         return HeartCreateResponse.of(store);
     }
 
@@ -39,7 +39,7 @@ public class HeartCommandService {
         Store store = storeFinder.findByIdWhereDeletedIsFalse(heartDeleteCommand.storeId());
         validateStoreHeartRemoval(user, store);
         heartDeleter.deleteHeart(user,store);
-        decreaseStoreHeartCount(store);
+        store.decreaseHeartCount();
         return HeartDeleteResponse.of(store);
     }
 
@@ -57,13 +57,5 @@ public class HeartCommandService {
 
     private void saveStoreHeart(final User user, final Store store) {
         heartUpdater.saveHeart(Heart.createHeart(user, store));
-    }
-
-    private void increaseStoreHeartCount(final Store store) {
-        store.increaseHeartCount();
-    }
-
-    private void decreaseStoreHeartCount(final Store store) {
-        store.decreaseHeartCount();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -19,10 +19,6 @@ public class StoreFinder {
 
     private final StoreRepository storeRepository;
 
-    public Store getStoreReference(final Long id) {
-        return storeRepository.getReferenceById(id);
-    }
-
     public Store findByIdWhereDeletedIsFalse(final Long id) {
         return storeRepository.findByIdAndIsDeletedIsFalse(id)
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));


### PR DESCRIPTION
## Related Issue 📌
close #148 

## Description ✔️
좋아요 생성 및 삭제 로직에서 부적절한 Store id값이 들어왔을 때 예외처리를 추가해주었습니다.

## To Reviewers
- User의 경우 Reference를 사용하면 쿼리가 나가지 않는다는 이점이 있어서 Reference 사용을 유지했습니다. 
   (+ User까지 예외처리를 하기는 너무나 과하다고 생각)
- 별개로 위 경도 값으로 식당 검증하기로 결정해서 store 엔티티에 address 속성은 필요 없지 않나요?