### PR TITLE
[feat] 식당 삭제 api

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -98,4 +98,10 @@ public class StoreController {
                                                          @UserId final Long userId) {
         return HankkiResponse.success(CommonSuccessCode.CREATED, storeCommandService.createStore(StorePostCommand.of(image, request, userId)));
     }
+
+    @DeleteMapping("/stores/{id}")
+    public HankkiResponse<Void> deleteStore(@PathVariable final Long id) {
+        storeCommandService.deleteStore(id);
+        return HankkiResponse.success(CommonSuccessCode.NO_CONTENT);
+    }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartDeleter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartDeleter.java
@@ -15,8 +15,4 @@ public class HeartDeleter {
     public void deleteHeart(final User user, final Store store) {
         heartRepository.deleteByUserAndStore(user, store);
     }
-
-    public void deleteHeart(final Store store) {
-        heartRepository.deleteHeartByStore(store);
-    }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/HeartDeleter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/HeartDeleter.java
@@ -15,4 +15,8 @@ public class HeartDeleter {
     public void deleteHeart(final User user, final Store store) {
         heartRepository.deleteByUserAndStore(user, store);
     }
+
+    public void deleteHeart(final Store store) {
+        heartRepository.deleteHeartByStore(store);
+    }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
@@ -42,6 +42,7 @@ public class StoreCommandService {
     private final ReportUpdater reportUpdater;
     private final UserFinder userFinder;
     private final StoreFinder storeFinder;
+    private final HeartDeleter heartDeleter;
 
     @Transactional(rollbackFor = Exception.class)
     public StorePostResponse createStore(final StorePostCommand command) {
@@ -90,6 +91,8 @@ public class StoreCommandService {
 
     @Transactional
     public void deleteStore(final Long id) {
-      storeFinder.findByIdWhereDeletedIsFalse(id).softDelete();
+      Store store = storeFinder.findByIdWhereDeletedIsFalse(id);
+      store.softDelete();
+      heartDeleter.deleteHeart(store);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
@@ -87,4 +87,9 @@ public class StoreCommandService {
                 .map(menuPostRequest -> Menu.create(store, menuPostRequest.name(), menuPostRequest.price()))
                 .toList();
     }
+
+    @Transactional
+    public void deleteStore(final Long id) {
+      storeFinder.findByIdWhereDeletedIsFalse(id).softDelete();
+    }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
@@ -42,7 +42,6 @@ public class StoreCommandService {
     private final ReportUpdater reportUpdater;
     private final UserFinder userFinder;
     private final StoreFinder storeFinder;
-    private final HeartDeleter heartDeleter;
 
     @Transactional(rollbackFor = Exception.class)
     public StorePostResponse createStore(final StorePostCommand command) {
@@ -91,8 +90,6 @@ public class StoreCommandService {
 
     @Transactional
     public void deleteStore(final Long id) {
-      Store store = storeFinder.findByIdWhereDeletedIsFalse(id);
-      store.softDelete();
-      heartDeleter.deleteHeart(store);
+      storeFinder.findByIdWhereDeletedIsFalse(id).softDelete();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -12,6 +12,7 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     boolean existsByUserAndStore(User user, Store store);
     void deleteByUserAndStore(User user, Store store);
+    void deleteHeartByStore(Store store);
 
     @Query("select h from Heart h join fetch h.store s join fetch s.images " +
             "where h.user.id = :userId and s.isDeleted = false order by h.id desc")

--- a/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/heart/repository/HeartRepository.java
@@ -12,7 +12,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     boolean existsByUserAndStore(User user, Store store);
     void deleteByUserAndStore(User user, Store store);
-    void deleteHeartByStore(Store store);
 
     @Query("select h from Heart h join fetch h.store s join fetch s.images " +
             "where h.user.id = :userId and s.isDeleted = false order by h.id desc")

--- a/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/model/Store.java
@@ -1,8 +1,6 @@
 package org.hankki.hankkiserver.domain.store.model;
 
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +10,9 @@ import org.hankki.hankkiserver.domain.common.Point;
 import org.hankki.hankkiserver.domain.heart.model.Heart;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -73,5 +74,9 @@ public class Store extends BaseTimeEntity {
 
     public void increaseHeartCount() {
         this.heartCount++;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }


### PR DESCRIPTION
## Related Issue 📌
close #145 

## Description ✔️
- 식당 삭제 api (soft delete)

## To Reviewers
api 테스트 완료

soft delete 범위를 어디까지 가져갈 지 고민.. 
지금 식당이랑 연결된 테이블이 굉장히 많은데, 식당을 삭제하면 다른 테이블들에 연관된 값들도 삭제할 것인지
-> 지금은 제보자가 클릭 한번으로 삭제를 할 수 있는 구조라서 만약 다 삭제하도록 구현했을 때, 악덕 사용자가 정상적인 식당을 삭제했을 때, 복구가 힘들 것 같음
-> 그래서 지금은 일단 isDeleted만 true로 바뀌고 해당 식당아이디를 좋아요한 목록들까지만 삭제해주었는데 다른 부분들도 삭제해주어야할 지 고민입니다.

*** 
기획과 합의 결과, isDeleted만 true로 바꾸기로 하였습니다.
