### PR TITLE
[fix] 기본 이미지 정책 변경에 따른 로직 수정

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hankki/hankkiserver/api/advice/GlobalExceptionHandler.java
@@ -4,15 +4,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.hankki.hankkiserver.api.dto.HankkiResponse;
 import org.hankki.hankkiserver.common.code.BusinessErrorCode;
 import org.hankki.hankkiserver.common.code.StoreErrorCode;
-import org.hankki.hankkiserver.common.exception.BadRequestException;
-import org.hankki.hankkiserver.common.exception.ConflictException;
-import org.hankki.hankkiserver.common.exception.NotFoundException;
-import org.hankki.hankkiserver.common.exception.UnauthorizedException;
+import org.hankki.hankkiserver.common.code.StoreImageErrorCode;
+import org.hankki.hankkiserver.common.exception.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 @RestControllerAdvice
 @Slf4j
@@ -58,6 +57,18 @@ public class GlobalExceptionHandler {
     public HankkiResponse<Void> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("handleMethodArgumentNotValidException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
         return HankkiResponse.fail(BusinessErrorCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SdkClientException.class)
+    public HankkiResponse<Void> handleSdkClientException(SdkClientException e) {
+        log.error("handleSdkClientException() in GlobalExceptionHandler throw SdkClientException : {}", e.getMessage());
+        return HankkiResponse.fail(StoreImageErrorCode.STORE_IMAGE_UPLOAD_FAILED);
+    }
+
+    @ExceptionHandler(BadGatewayException.class)
+    public HankkiResponse<Void> handleBadGatewayException(BadGatewayException e) {
+        log.error("handleBadGatewayException() in GlobalExceptionHandler throw BadGatewayException : {}", e.getMessage());
+        return HankkiResponse.fail(e.getErrorCode());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java
@@ -9,6 +9,8 @@ import org.hankki.hankkiserver.api.store.service.response.StorePostResponse;
 import org.hankki.hankkiserver.api.university.service.UniversityFinder;
 import org.hankki.hankkiserver.api.universitystore.service.UniversityStoreUpdater;
 import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.common.code.StoreImageErrorCode;
+import org.hankki.hankkiserver.common.exception.BadGatewayException;
 import org.hankki.hankkiserver.common.exception.BadRequestException;
 import org.hankki.hankkiserver.domain.menu.model.Menu;
 import org.hankki.hankkiserver.domain.report.model.Report;
@@ -65,15 +67,12 @@ public class StoreCommandService {
     }
 
     private void saveImages(final StorePostCommand command, final Store store) {
-        if (isNullOrEmptyImage(command)) {
-            storeImageUpdater.saveImage(StoreImage.createImage(store, DEFAULT_IMAGE_URL));
-        }
-        else {
+        if (!isNullOrEmptyImage(command)) {
             try {
                 String imageUrl = s3Service.uploadImage(STORE_IMAGE_DIRECTORY, command.image());
                 storeImageUpdater.saveImage(StoreImage.createImage(store, imageUrl));
             } catch (IOException e) {
-                storeImageUpdater.saveImage(StoreImage.createImage(store, DEFAULT_IMAGE_URL));
+                throw new BadGatewayException(StoreImageErrorCode.STORE_IMAGE_UPLOAD_FAILED);
             }
         }
     }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreResponse.java
@@ -11,6 +11,11 @@ public record StoreResponse (
         int heartCount
 ) {
     public static StoreResponse of(final Store store) {
-        return new StoreResponse(store.getId(), store.getImages().get(0).getImageUrl(), store.getCategory().getName(), store.getName(), store.getLowestPrice(), store.getHeartCount());
+        return new StoreResponse(store.getId(),
+                store.getImages().isEmpty() ? null : store.getImages().get(0).getImageUrl(),
+                store.getCategory().getName(),
+                store.getName(),
+                store.getLowestPrice(),
+                store.getHeartCount());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -11,23 +11,13 @@ public record StoreThumbnailResponse(
         String imageUrl
 ) {
     public static StoreThumbnailResponse of(final Store store) {
-        if (store.getImages().isEmpty()) {
-            return new StoreThumbnailResponse(
-                    store.getId(),
-                    store.getName(),
-                    store.getCategory().getName(),
-                    store.getLowestPrice(),
-                    store.getHeartCount(),
-                    null
-            );
-        }
         return new StoreThumbnailResponse(
                 store.getId(),
                 store.getName(),
                 store.getCategory().getName(),
                 store.getLowestPrice(),
                 store.getHeartCount(),
-                store.getImages().get(0).getImageUrl()
+                store.getImages().isEmpty() ? null : store.getImages().get(0).getImageUrl()
         );
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreThumbnailResponse.java
@@ -11,6 +11,16 @@ public record StoreThumbnailResponse(
         String imageUrl
 ) {
     public static StoreThumbnailResponse of(final Store store) {
+        if (store.getImages().isEmpty()) {
+            return new StoreThumbnailResponse(
+                    store.getId(),
+                    store.getName(),
+                    store.getCategory().getName(),
+                    store.getLowestPrice(),
+                    store.getHeartCount(),
+                    null
+            );
+        }
         return new StoreThumbnailResponse(
                 store.getId(),
                 store.getName(),

--- a/src/main/java/org/hankki/hankkiserver/common/code/StoreImageErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/StoreImageErrorCode.java
@@ -1,0 +1,15 @@
+package org.hankki.hankkiserver.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreImageErrorCode implements ErrorCode {
+
+    STORE_IMAGE_UPLOAD_FAILED(HttpStatus.BAD_GATEWAY, "외부 자징소에 이미지 업로드에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/hankki/hankkiserver/common/exception/BadGatewayException.java
+++ b/src/main/java/org/hankki/hankkiserver/common/exception/BadGatewayException.java
@@ -1,0 +1,14 @@
+package org.hankki.hankkiserver.common.exception;
+
+import lombok.Getter;
+import org.hankki.hankkiserver.common.code.ErrorCode;
+
+@Getter
+public class BadGatewayException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BadGatewayException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
close #156 

## Description ✔️
- 식당 썸네일 조회시 default이미지를 사용한다면 imageUrl을 null로 반환합니다.
- 식당 리스트 조회시 default이미지를 사용한다면 imageUrl을 null로 반환합니다.
- 식당 세부 조회에서는 빈리스트를 반환합니다 -> 로직 변경 없음
- 기본이미지를 서버에서 관리하지 않게 됨에 따라 식당 생성 로직에서 이미지가 업로드되지 않았다면 storeImage를 저장하지 않도록 변경했습니다.
## To Reviewers
<img width="723" alt="스크린샷 2024-08-13 오후 8 28 58" src="https://github.com/user-attachments/assets/688390d9-77e9-47fe-930a-889d3a1ee4db">
<img width="302" alt="스크린샷 2024-08-13 오후 8 29 21" src="https://github.com/user-attachments/assets/5d96273d-ed89-4363-b317-0d3c7f87638c">

