### PR TITLE
[feat] 족보 제목 중복 예외 처리

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
@@ -24,7 +24,7 @@ public class FavoriteController {
 
   @PostMapping("/favorites")
   public HankkiResponse<Void> createFavorite(@UserId final Long userId, @RequestBody @Valid final FavoritePostRequest request) {
-    favoriteCommandService.create(FavoritePostCommand.of(userId, request));
+    favoriteCommandService.createFavorite(FavoritePostCommand.of(userId, request));
     return HankkiResponse.success(CommonSuccessCode.CREATED);
   }
 

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
@@ -24,14 +24,12 @@ public class FavoriteController {
 
   @PostMapping("/favorites")
   public HankkiResponse<Void> createFavorite(@UserId final Long userId, @RequestBody @Valid final FavoritePostRequest request) {
-
     favoriteCommandService.create(FavoritePostCommand.of(userId, request));
     return HankkiResponse.success(CommonSuccessCode.CREATED);
   }
 
   @PostMapping("/favorites/batch-delete")
   public HankkiResponse<Void> deleteFavorite(@UserId final Long userId, @RequestBody final FavoriteDeleteRequest request) {
-
     favoriteCommandService.deleteFavorites(FavoritesDeleteCommand.of(userId, request));
     return HankkiResponse.success(CommonSuccessCode.NO_CONTENT);
   }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/request/FavoritePostRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/request/FavoritePostRequest.java
@@ -9,6 +9,6 @@ public record FavoritePostRequest(
     @Size(max = 18, message = "제목 길이가 18자를 초과했습니다.")
     String title,
     @Size(min = 1, max = 2, message = "해시태그 리스트 size가 1 이상 2 이하가 아닙니다.")
-    List<@Size(min = 2, max= 10, message = "해시태그가 # 포함 10자를 초과했습니다.") String> details
+    List<@Size(min = 2, max= 9, message = "해시태그가 # 포함 9자를 초과했습니다.") String> details
 ) {
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
@@ -11,6 +11,7 @@ import org.hankki.hankkiserver.api.favoritestore.service.FavoriteStoreDeleter;
 import org.hankki.hankkiserver.api.favoritestore.service.FavoriteStoreFinder;
 import org.hankki.hankkiserver.api.favoritestore.service.FavoriteStoreUpdater;
 import org.hankki.hankkiserver.api.store.service.StoreFinder;
+import org.hankki.hankkiserver.common.code.FavoriteErrorCode;
 import org.hankki.hankkiserver.common.code.FavoriteStoreErrorCode;
 import org.hankki.hankkiserver.common.code.UserErrorCode;
 import org.hankki.hankkiserver.common.exception.ConflictException;
@@ -40,9 +41,8 @@ public class FavoriteCommandService {
 
     User findUser = userFinder.getUser(command.userId());
     String title = command.title();
-    String details = String.join(" ", command.details());
-
-    return favoriteUpdater.save(Favorite.create(findUser, title, details));
+    checkTitleExists(title, findUser);
+    return favoriteUpdater.save(Favorite.create(findUser, title, String.join(" ", command.details())));
   }
 
   @Transactional
@@ -91,5 +91,11 @@ public class FavoriteCommandService {
 
   private boolean isAlreadyExistsFavoriteStore(final Long favoriteId, final Long storeId){
     return favoriteStoreFinder.isExist(favoriteId, storeId);
+  }
+
+  private void checkTitleExists(final String title, final User user){
+    favoriteFinder.findByNameAndUser(title, user).ifPresent(f -> {
+      throw new ConflictException(FavoriteErrorCode.FAVORITE_TITLE_IS_EXIST);
+    });
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
@@ -1,6 +1,5 @@
 package org.hankki.hankkiserver.api.favorite.service;
 
-import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.auth.service.UserFinder;
@@ -22,6 +21,7 @@ import org.hankki.hankkiserver.domain.favoritestore.model.FavoriteStore;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
@@ -37,7 +37,7 @@ public class FavoriteCommandService {
   private final FavoriteDeleter favoriteDeleter;
 
   @Transactional
-  public Long create(final FavoritePostCommand command) {
+  public Long createFavorite(final FavoritePostCommand command) {
 
     User findUser = userFinder.getUser(command.userId());
     String title = command.title();
@@ -95,7 +95,7 @@ public class FavoriteCommandService {
 
   private void checkTitleExists(final String title, final User user){
     favoriteFinder.findByNameAndUser(title, user).ifPresent(f -> {
-      throw new ConflictException(FavoriteErrorCode.FAVORITE_TITLE_IS_EXIST);
+      throw new ConflictException(FavoriteErrorCode.FAVORITE_TITLE_EXISTS);
     });
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteFinder.java
@@ -1,11 +1,13 @@
 package org.hankki.hankkiserver.api.favorite.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.common.code.FavoriteErrorCode;
 import org.hankki.hankkiserver.common.exception.NotFoundException;
 import org.hankki.hankkiserver.domain.favorite.model.Favorite;
 import org.hankki.hankkiserver.domain.favorite.repository.FavoriteRepository;
+import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +33,11 @@ public class FavoriteFinder {
   }
 
   protected Favorite findByIdWithFavoriteStore(final Long id) {
-    return favoriteRepository.findByIdWithFavoriteStore(id).orElseThrow(() -> new NotFoundException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+    return favoriteRepository.findByIdWithFavoriteStore(id)
+        .orElseThrow(() -> new NotFoundException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+  }
+
+  protected Optional<Favorite> findByNameAndUser(final String name, final User user) {
+    return favoriteRepository.findByNameAndUser(name, user);
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/common/code/FavoriteErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/FavoriteErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FavoriteErrorCode implements ErrorCode {
 
-  FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 족보입니다.");
+  FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 족보입니다."),
+  FAVORITE_TITLE_IS_EXIST(HttpStatus.CONFLICT, "이미 존재하는 족보 제목입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/org/hankki/hankkiserver/common/code/FavoriteErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/FavoriteErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum FavoriteErrorCode implements ErrorCode {
 
   FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 족보입니다."),
-  FAVORITE_TITLE_IS_EXIST(HttpStatus.CONFLICT, "이미 존재하는 족보 제목입니다.");
+  FAVORITE_TITLE_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 족보 제목입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/org/hankki/hankkiserver/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/favorite/repository/FavoriteRepository.java
@@ -3,6 +3,7 @@ package org.hankki.hankkiserver.domain.favorite.repository;
 import java.util.List;
 import java.util.Optional;
 import org.hankki.hankkiserver.domain.favorite.model.Favorite;
+import org.hankki.hankkiserver.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
   @Query("select f from Favorite f left join fetch f.favoriteStores where f.id = :favoriteId")
   Optional<Favorite> findByIdWithFavoriteStore(@Param("favoriteId") Long favoriteId);
+
+  Optional<Favorite> findByNameAndUser(String title, User user);
 }


### PR DESCRIPTION
## Related Issue 📌
close #150 

## Description ✔️
- 족보 제목 중복 예외 처리
- 해시태그 [#일이삼사오육칠팔] 까지만 된다고 하여 max를 9로 지정
- where 절에 족보 제목 & 유저로 검색하는 로직 추가

## To Reviewers
- 테스트완료
```json
{
	"code": 409,
	"message": "이미 존재하는 족보 제목입니다."
}
```
