### PR TITLE
[fix] 식당 제보 validation 검증 조건 추가 

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -83,7 +83,7 @@ public class StoreController {
 
     @PostMapping("/stores/validate")
     public HankkiResponse<StoreDuplicateValidationResponse> validateDuplicatedStore(@RequestBody final StoreDuplicateValidationRequest request) {
-        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.validateDuplicatedStore(StoreValidationCommand.of(request.universityId(), request.latitude(), request.longitude())));
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.validateDuplicatedStore(StoreValidationCommand.of(request.universityId(), request.latitude(), request.longitude(), request.storeName())));
     }
 
     @PostMapping("/stores")

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -82,7 +82,7 @@ public class StoreController {
     }
 
     @PostMapping("/stores/validate")
-    public HankkiResponse<StoreDuplicateValidationResponse> validateDuplicatedStore(@RequestBody final StoreDuplicateValidationRequest request) {
+    public HankkiResponse<StoreDuplicateValidationResponse> validateDuplicatedStore(@RequestBody @Valid final StoreDuplicateValidationRequest request) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.validateDuplicatedStore(StoreValidationCommand.of(request.universityId(), request.latitude(), request.longitude(), request.storeName())));
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/request/StoreDuplicateValidationRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/request/StoreDuplicateValidationRequest.java
@@ -1,9 +1,16 @@
 package org.hankki.hankkiserver.api.store.controller.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record StoreDuplicateValidationRequest(
+        @NotNull
         long universityId,
+        @NotNull
         double latitude,
+        @NotNull
         double longitude,
+        @NotBlank
         String storeName
 ) {
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/request/StoreDuplicateValidationRequest.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/request/StoreDuplicateValidationRequest.java
@@ -3,6 +3,7 @@ package org.hankki.hankkiserver.api.store.controller.request;
 public record StoreDuplicateValidationRequest(
         long universityId,
         double latitude,
-        double longitude
+        double longitude,
+        String storeName
 ) {
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -29,7 +29,7 @@ public class StoreFinder {
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    protected Optional<Store> findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(final double latitude, final double longitude, String name) {
+    protected Optional<Store> findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(final double latitude, final double longitude, final String name) {
         return storeRepository.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(latitude, longitude, name);
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -29,8 +29,8 @@ public class StoreFinder {
                 .orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    protected Optional<Store> findByLatitudeAndLongitudeWhereIsDeletedFalse(final double latitude, final double longitude) {
-        return storeRepository.findByPoint_LatitudeAndPoint_LongitudeAndIsDeletedFalse(latitude, longitude);
+    protected Optional<Store> findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(final double latitude, final double longitude, String name) {
+        return storeRepository.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(latitude, longitude, name);
     }
 
     protected boolean existsByLatitudeAndLongitude(final double latitude, final double longitude) {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -79,6 +79,11 @@ public class StoreQueryService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public StoreDuplicateValidationResponse validateDuplicatedStore(final StoreValidationCommand command) {
+        return createStoreDuplicateValidationResponse(storeFinder.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(command.latitude(), command.longitude(), command.name()), command.universityId());
+    }
+
     private List<MenuResponse> getMenus(final Store store) {
         return menuFinder.findAllByStore(store).stream().map(MenuResponse::of).toList();
     }
@@ -89,11 +94,6 @@ public class StoreQueryService {
 
     private boolean hasSameUserId(final Long id, final Heart heart) {
         return heart.getUser().getId().equals(id);
-    }
-
-    @Transactional(readOnly = true)
-    public StoreDuplicateValidationResponse validateDuplicatedStore(final StoreValidationCommand command) {
-        return createStoreDuplicateValidationResponse(storeFinder.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(command.latitude(), command.longitude(), command.name()), command.universityId());
     }
 
     private StoreDuplicateValidationResponse createStoreDuplicateValidationResponse(Optional<Store> store, Long universityId) {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -92,8 +93,11 @@ public class StoreQueryService {
 
     @Transactional(readOnly = true)
     public StoreDuplicateValidationResponse validateDuplicatedStore(final StoreValidationCommand command) {
-        return storeFinder.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(command.latitude(), command.longitude(), command.name())
-                .map(store -> StoreDuplicateValidationResponse.of(store.getId(), universityStoreFinder.existsByUniversityIdAndStore(command.universityId(), store)))
+        return createStoreDuplicateValidationResponse(storeFinder.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(command.latitude(), command.longitude(), command.name()), command.universityId());
+    }
+
+    private StoreDuplicateValidationResponse createStoreDuplicateValidationResponse(Optional<Store> store, Long universityId) {
+        return store.map(s -> StoreDuplicateValidationResponse.of(s.getId(), universityStoreFinder.existsByUniversityIdAndStore(universityId, s)))
                 .orElseGet(() -> StoreDuplicateValidationResponse.of(null, false));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -92,7 +92,7 @@ public class StoreQueryService {
 
     @Transactional(readOnly = true)
     public StoreDuplicateValidationResponse validateDuplicatedStore(final StoreValidationCommand command) {
-        return storeFinder.findByLatitudeAndLongitudeWhereIsDeletedFalse(command.latitude(), command.longitude())
+        return storeFinder.findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(command.latitude(), command.longitude(), command.name())
                 .map(store -> StoreDuplicateValidationResponse.of(store.getId(), universityStoreFinder.existsByUniversityIdAndStore(command.universityId(), store)))
                 .orElseGet(() -> StoreDuplicateValidationResponse.of(null, false));
     }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/command/StoreValidationCommand.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/command/StoreValidationCommand.java
@@ -3,9 +3,10 @@ package org.hankki.hankkiserver.api.store.service.command;
 public record StoreValidationCommand (
         long universityId,
         double latitude,
-        double longitude
+        double longitude,
+        String name
 ) {
-    public static StoreValidationCommand of(long universityId, double latitude, double longitude) {
-        return new StoreValidationCommand(universityId, latitude, longitude);
+    public static StoreValidationCommand of(long universityId, double latitude, double longitude, String name) {
+        return new StoreValidationCommand(universityId, latitude, longitude, name);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/StoreRepository.java
@@ -15,8 +15,8 @@ public interface StoreRepository extends JpaRepository<Store, Long>, CustomStore
     @Query("select distinct s from Store s left join fetch s.hearts where s.id = :id and s.isDeleted = false")
     Optional<Store> findByIdWithHeartAndIsDeletedFalse(Long id);
 
-    @Query("select s from Store s where s.point.latitude = :latitude and s.point.longitude = :longitude and s.isDeleted = false")
-    Optional<Store> findByPoint_LatitudeAndPoint_LongitudeAndIsDeletedFalse(double latitude, double longitude);
+    @Query("select s from Store s where s.point.latitude = :latitude and s.point.longitude = :longitude and s.name = :name and s.isDeleted = false")
+    Optional<Store> findByLatitudeAndLongitudeAndNameWhereIsDeletedFalse(double latitude, double longitude, String name);
 
     boolean existsByPoint_LatitudeAndPoint_Longitude(double latitude, double longitude);
 


### PR DESCRIPTION
## Related Issue 📌
close #168 

## Description ✔️
- 같은 건물 다른 층에 위치한 식당의 경우, 위 경도 값이 일치하는 문제가 발생하여 식당 이름을 검증 조건을 추가합니다.

## To Reviewers
추가적으로 식당 삭제할 때 어떻게 처리할지에 대해 기획분들께 물어봤는데 릴리즈할 때까지 시간이 얼마 남지 않아 식당 삭제 제보가 들어오고 나서 재제보하는 것을 막지 않는다고 합니다. 때문에 식당 등록 로직에서 검증 로직 빼야할 것 같습니다. 
https://github.com/Team-Hankki/hankki-server/blob/e3f871d155ac02d23c3bf68b5e7bf17bc583d8ac/src/main/java/org/hankki/hankkiserver/api/store/service/StoreCommandService.java#L50-L52
이 부분 삭제해야함다. (지금 저 로직이 포함되어 있으면 삭제된 식당에 대한 재제보가 막히게돼요!)
