### PR TITLE
[fix] image_url 컬럼 타입 TEXT로 변경

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/domain/store/model/StoreImage.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/model/StoreImage.java
@@ -21,7 +21,7 @@ public class StoreImage extends BaseCreatedAtEntity {
     @JoinColumn(name = "store_id")
     private Store store;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
     @Builder


### PR DESCRIPTION
## Related Issue 📌
close #182 

## Description ✔️
- 255자를 넘는 url이 있어 타입 TEXT로 변경했습니다.

## To Reviewers
