### PR TITLE
[feat] 족보 주인 닉네임 조회 API

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
@@ -10,6 +10,7 @@ import org.hankki.hankkiserver.api.favorite.service.FavoriteCommandService;
 import org.hankki.hankkiserver.api.favorite.service.FavoriteQueryService;
 import org.hankki.hankkiserver.api.favorite.service.command.*;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
 import org.hankki.hankkiserver.auth.UserId;
@@ -77,5 +78,10 @@ public class FavoriteController {
   @GetMapping("/favorites/{favoriteId}/ownership")
   public HankkiResponse<FavoriteOwnershipGetResponse> checkFavoriteOwnership(@UserId Long userId, @PathVariable("favoriteId") final long favoriteId) {
     return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.checkFavoriteOwnership(FavoriteOwnershipGetCommand.of(userId, favoriteId)));
+  }
+
+  @GetMapping("/favorites/{favoriteId}/users/me")
+  public HankkiResponse<FavoriteNicknameGetResponse> getFavoriteUserNickname(@PathVariable("favoriteId") final long id) {
+    return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.getFavoriteUserNickname(id));
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
@@ -10,7 +10,7 @@ import org.hankki.hankkiserver.api.favorite.service.FavoriteCommandService;
 import org.hankki.hankkiserver.api.favorite.service.FavoriteQueryService;
 import org.hankki.hankkiserver.api.favorite.service.command.*;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
-import org.hankki.hankkiserver.api.favorite.service.response.FavoriteNicknameGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteUserNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
 import org.hankki.hankkiserver.auth.UserId;
@@ -81,7 +81,7 @@ public class FavoriteController {
   }
 
   @GetMapping("/favorites/{favoriteId}/users/me")
-  public HankkiResponse<FavoriteNicknameGetResponse> getFavoriteUserNickname(@PathVariable("favoriteId") final long id) {
+  public HankkiResponse<FavoriteUserNicknameGetResponse> getFavoriteUserNickname(@PathVariable("favoriteId") final long id) {
     return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.getFavoriteUserNickname(id));
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
@@ -7,7 +7,7 @@ import org.hankki.hankkiserver.api.favorite.service.command.FavoriteOwnershipGet
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesWithStatusGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
-import org.hankki.hankkiserver.api.favorite.service.response.FavoriteNicknameGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteUserNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
 import org.hankki.hankkiserver.api.store.service.StoreFinder;
@@ -76,8 +76,8 @@ public class FavoriteQueryService {
   }
 
   @Transactional(readOnly = true)
-  public FavoriteNicknameGetResponse getFavoriteUserNickname(final long id) {
-    return FavoriteNicknameGetResponse.of(getNicknameByOwnerId(getOwnerIdById(id)));
+  public FavoriteUserNicknameGetResponse getFavoriteUserNickname(final long id) {
+    return FavoriteUserNicknameGetResponse.of(getNicknameByOwnerId(getOwnerIdById(id)));
   }
 
   private String getNicknameByOwnerId(final long userId) {

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
@@ -2,10 +2,12 @@ package org.hankki.hankkiserver.api.favorite.service;
 
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.auth.service.UserInfoFinder;
 import org.hankki.hankkiserver.api.favorite.service.command.FavoriteOwnershipGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesWithStatusGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
 import org.hankki.hankkiserver.api.store.service.StoreFinder;
@@ -25,6 +27,7 @@ public class FavoriteQueryService {
 
   private final FavoriteFinder favoriteFinder;
   private final StoreFinder storeFinder;
+  private final UserInfoFinder userInfoFinder;
 
   @Transactional(readOnly = true)
   public FavoriteGetResponse findFavorite(final FavoritesGetCommand command) {
@@ -59,6 +62,7 @@ public class FavoriteQueryService {
     return favorite.getFavoriteStores().isEmpty();
   }
 
+  @Transactional(readOnly = true)
   public FavoriteOwnershipGetResponse checkFavoriteOwnership(final FavoriteOwnershipGetCommand command) {
      return FavoriteOwnershipGetResponse.of(isOwner(getOwnerIdById(command.favoriteId()), command.userId()));
   }
@@ -69,5 +73,14 @@ public class FavoriteQueryService {
 
   private boolean isOwner(final long ownerId, final long userId) {
     return ownerId == userId;
+  }
+
+  @Transactional(readOnly = true)
+  public FavoriteNicknameGetResponse getFavoriteUserNickname(final long id) {
+    return FavoriteNicknameGetResponse.of(getNicknameByOwnerId(getOwnerIdById(id)));
+  }
+
+  private String getNicknameByOwnerId(final long userId) {
+    return userInfoFinder.getUserInfo(userId).getNickname();
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteNicknameGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteNicknameGetResponse.java
@@ -1,0 +1,9 @@
+package org.hankki.hankkiserver.api.favorite.service.response;
+
+public record FavoriteNicknameGetResponse(
+    String nickname
+) {
+  public static FavoriteNicknameGetResponse of(final String nickname) {
+    return new FavoriteNicknameGetResponse(nickname);
+  }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteNicknameGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteNicknameGetResponse.java
@@ -1,9 +1,0 @@
-package org.hankki.hankkiserver.api.favorite.service.response;
-
-public record FavoriteNicknameGetResponse(
-    String nickname
-) {
-  public static FavoriteNicknameGetResponse of(final String nickname) {
-    return new FavoriteNicknameGetResponse(nickname);
-  }
-}

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteUserNicknameGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteUserNicknameGetResponse.java
@@ -1,0 +1,9 @@
+package org.hankki.hankkiserver.api.favorite.service.response;
+
+public record FavoriteUserNicknameGetResponse(
+    String nickname
+) {
+  public static FavoriteUserNicknameGetResponse of(final String nickname) {
+    return new FavoriteUserNicknameGetResponse(nickname);
+  }
+}


### PR DESCRIPTION
## Related Issue 📌
close #230 

## Description ✔️
- 족보 주인 닉네임 조회 API입니다. 

## To Reviewers
- favoriteId를 통해 족보 주인의 ID(FK)를, 그 ID로 UserInfo의 nickname을 조회합니다. 
```sql
Hibernate: 
    select
        f1_0.favorite_id,
        f1_0.created_at,
        f1_0.detail,
        f1_0.image_type,
        f1_0.name,
        f1_0.updated_at,
        f1_0.user_id 
    from
        favorite f1_0 
    where
        f1_0.favorite_id=?
Hibernate: 
    select
        ui1_0.user_info_id,
        ui1_0.nickname,
        ui1_0.refresh_token,
        ui1_0.user_id 
    from
        user_info ui1_0 
    where
        ui1_0.user_id=?
```