### PR TITLE
[feat] 족보 공유 관련 API 분리, 시큐리티 whiteList에 추가

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/controller/FavoriteController.java
@@ -12,6 +12,7 @@ import org.hankki.hankkiserver.api.favorite.service.command.*;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteUserNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteSharedGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
 import org.hankki.hankkiserver.auth.UserId;
 import org.hankki.hankkiserver.common.code.CommonSuccessCode;
@@ -69,13 +70,13 @@ public class FavoriteController {
     return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.findFavoritesWithStatus(FavoritesWithStatusGetCommand.of(id, storeId)));
   }
 
-  @PostMapping("/favorites/{favoriteId}/shared")
+  @PostMapping("/favorites/shared/{favoriteId}")
   public HankkiResponse<Void> createSharedFavorite(@UserId final Long userId, @PathVariable(name = "favoriteId") long favoriteId, @RequestBody @Valid final FavoriteSharedPostRequest request) {
     favoriteCommandService.createSharedFavorite(FavoriteSharedPostCommand.of(userId, favoriteId, request.title(), request.details()));
     return HankkiResponse.success(CommonSuccessCode.CREATED);
   }
 
-  @GetMapping("/favorites/{favoriteId}/ownership")
+  @GetMapping("/favorites/shared/{favoriteId}/ownership")
   public HankkiResponse<FavoriteOwnershipGetResponse> checkFavoriteOwnership(@UserId Long userId, @PathVariable("favoriteId") final long favoriteId) {
     return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.checkFavoriteOwnership(FavoriteOwnershipGetCommand.of(userId, favoriteId)));
   }
@@ -83,5 +84,10 @@ public class FavoriteController {
   @GetMapping("/favorites/{favoriteId}/users/me")
   public HankkiResponse<FavoriteUserNicknameGetResponse> getFavoriteUserNickname(@PathVariable("favoriteId") final long id) {
     return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.getFavoriteUserNickname(id));
+  }
+
+  @GetMapping("/favorites/shared/{favoriteId}")
+  public HankkiResponse<FavoriteSharedGetResponse> getSharedFavorite(@PathVariable(name = "favoriteId") final long id) {
+    return HankkiResponse.success(CommonSuccessCode.OK, favoriteQueryService.findSharedFavorite(id));
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteQueryService.java
@@ -7,6 +7,7 @@ import org.hankki.hankkiserver.api.favorite.service.command.FavoriteOwnershipGet
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.command.FavoritesWithStatusGetCommand;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteGetResponse;
+import org.hankki.hankkiserver.api.favorite.service.response.FavoriteSharedGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteUserNicknameGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoriteOwnershipGetResponse;
 import org.hankki.hankkiserver.api.favorite.service.response.FavoritesWithStatusGetResponse;
@@ -44,6 +45,12 @@ public class FavoriteQueryService {
                 favorite -> isStoreAlreadyAdded(favorite.getFavoriteStores(),  command.storeId()),
                 (oldValue, newValue) -> oldValue,
                 LinkedHashMap::new)));
+  }
+
+  @Transactional(readOnly = true)
+  public FavoriteSharedGetResponse findSharedFavorite(final long id) {
+    Favorite favorite = favoriteFinder.findByIdWithFavoriteStore(id);
+    return FavoriteSharedGetResponse.of(favorite, getNicknameByOwnerId(getOwnerIdById(id)), findStoresInFavorite(favorite));
   }
 
   private boolean isStoreAlreadyAdded(final List<FavoriteStore> favoriteStore, final Long commandStoreId) {

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteSharedGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteSharedGetResponse.java
@@ -1,0 +1,22 @@
+package org.hankki.hankkiserver.api.favorite.service.response;
+
+import static org.hankki.hankkiserver.api.favorite.service.response.util.FavoriteResponseUtil.transformDetail;
+
+import java.util.List;
+import org.hankki.hankkiserver.domain.favorite.model.Favorite;
+import org.hankki.hankkiserver.domain.store.model.Store;
+
+public record FavoriteSharedGetResponse(
+    String title,
+    List<String> details,
+    String nickname,
+    List<FavoriteStoreResponse> stores
+) {
+  public static FavoriteSharedGetResponse of(final Favorite favorite, final String nickname, final List<Store> stores) {
+    return new FavoriteSharedGetResponse(
+        favorite.getName(),
+        transformDetail(favorite.getDetail()),
+        nickname,
+        stores.stream().map(FavoriteStoreResponse::of).toList());
+  }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteSharedGetResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/response/FavoriteSharedGetResponse.java
@@ -10,13 +10,32 @@ public record FavoriteSharedGetResponse(
     String title,
     List<String> details,
     String nickname,
-    List<FavoriteStoreResponse> stores
+    List<FavoriteSharedResponse> stores
 ) {
   public static FavoriteSharedGetResponse of(final Favorite favorite, final String nickname, final List<Store> stores) {
     return new FavoriteSharedGetResponse(
         favorite.getName(),
         transformDetail(favorite.getDetail()),
         nickname,
-        stores.stream().map(FavoriteStoreResponse::of).toList());
+        stores.stream().map(FavoriteSharedResponse::of).toList());
+  }
+
+  record FavoriteSharedResponse(
+      Long id,
+      String name,
+      String imageUrl,
+      String category,
+      int lowestPrice,
+      int heartCount
+  ) {
+    static FavoriteSharedResponse of(final Store store) {
+      return new FavoriteSharedResponse(
+          store.getId(),
+          store.getName(),
+          store.getImageUrlOrElseNull(),
+          store.getCategory().getName(),
+          store.getLowestPrice(),
+          store.getHeartCount());
+    }
   }
 }

--- a/src/main/java/org/hankki/hankkiserver/auth/config/SecurityConfig.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
 
     private static final String[] authWhiteList = {"/api/v1/auth/login", "/api/v1/auth/reissue", "/actuator/health"};
     private static final String[] businessLogicWhileList = {"/api/v1/stores/categories", "/api/v1/stores/sort-options", "/api/v1/stores/price-categories",
-    "/api/v1/stores", "/api/v1/stores/pins", "/api/v1/stores/{articleId:\\d+}/thumbnail", "/api/v1/universities"};
+    "/api/v1/stores", "/api/v1/stores/pins", "/api/v1/stores/{articleId:\\d+}/thumbnail", "/api/v1/universities", "/api/v1/favorites/shared/{favoriteId:\\d+}"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
## Related Issue 📌
close #232 

## Description ✔️
- 족보 공유 관련 API 분리 - 시큐리티 whiteList에 추가
- 족보 상세보기 API와 공유 족보 상세보기 API를 분리했습니다. 

## To Reviewers
