### PR TITLE
[fix] 공유족보 생성 시 imageType 바뀌지 않는 문제 fix

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/favorite/service/FavoriteCommandService.java
@@ -100,7 +100,9 @@ public class FavoriteCommandService {
   }
 
   private void copySharedFavoriteStore(final long sharedId, final Favorite myFavorite) {
-    findStoresById(sharedId).forEach(it -> favoriteStoreUpdater.save(FavoriteStore.create(it, myFavorite)));
+    List<Store> storesInFavoriteStore = findStoresById(sharedId);
+    storesInFavoriteStore.forEach(it -> favoriteStoreUpdater.save(FavoriteStore.create(it, myFavorite)));
+    myFavorite.updateImageByFavoriteStoreCount(storesInFavoriteStore.size());
   }
 
   private List<Store> findStoresById(final long id) {


### PR DESCRIPTION
## Related Issue 📌
close #238 

## Description ✔️
- 공유족보에서 imageType 바뀌지 않는 문제 fix

## To Reviewers
상대방 FavoriteStore를 조회한 쿼리 반환값에서 size()를 통해 업데이트하게 했습니다.
