### PR TITLE
[refac] 메뉴 추가 시 발생 쿼리문 개선

### DIFF
--- a/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
@@ -37,7 +37,7 @@ public class MenuCommandService {
         Menu menu = menuFinder.findByStoreIdAndId(findStore.getId(), command.id());
         menuDeleter.deleteMenu(menu);
         saveToDeletedMenu(menu, findStore.getId());
-        updateLowestPriceInStore(storeFinder.findByIdWhereDeletedIsFalse(command.storeId()));
+        updateLowestPriceInStore(findStore);
         checkNoMenuInStore(findStore, command.userId());
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
@@ -1,6 +1,8 @@
 package org.hankki.hankkiserver.api.menu.service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.menu.service.command.MenuDeleteCommand;
 import org.hankki.hankkiserver.api.menu.service.command.MenuPatchCommand;
@@ -49,11 +51,7 @@ public class MenuCommandService {
     @Transactional
     public MenusPostResponse createMenus(final MenusPostCommand command) {
         Store findStore = storeFinder.findByIdWhereDeletedIsFalse(command.storeId());
-        List<Menu> allMenus = menuFinder.findAllByStore(findStore);
-        List<Menu> menus = command.menu().stream()
-                .filter(c -> !validateMenuConflict(allMenus, c.name()))
-                .map(c -> Menu.create(findStore, c.name(), c.price()))
-                .toList();
+        List<Menu> menus = filterNewMenu(command, findStore);
         menuUpdater.saveAll(menus);
         updateLowestPriceInStore(findStore);
         return MenusPostResponse.of(menus);
@@ -70,8 +68,22 @@ public class MenuCommandService {
         findStore.updateLowestPrice(menuFinder.findLowestPriceByStore(findStore));
     }
 
-    private boolean validateMenuConflict(final List<Menu> menus, final String menuName) {
-        return menus.stream().anyMatch(menu -> menu.getName().equals(menuName));
+    private List<Menu> filterNewMenu(final MenusPostCommand command, final Store store) {
+        Set<String> allMenuNames = parseAllMenuNames(store);
+        return command.menu().stream()
+                .filter(c -> !validateMenuConflict(allMenuNames, c.name()))
+                .map(c -> Menu.create(store, c.name(), c.price()))
+                .toList();
+    }
+
+    private Set<String> parseAllMenuNames(final Store store) {
+        return menuFinder.findAllByStore(store).stream()
+                .map(Menu::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean validateMenuConflict(final Set<String> menus, final String menuName) {
+        return menus.contains(menuName);
     }
 
     private void checkNoMenuInStore(final Store store, final long userId) {

--- a/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/menu/service/MenuCommandService.java
@@ -49,8 +49,9 @@ public class MenuCommandService {
     @Transactional
     public MenusPostResponse createMenus(final MenusPostCommand command) {
         Store findStore = storeFinder.findByIdWhereDeletedIsFalse(command.storeId());
+        List<Menu> allMenus = menuFinder.findAllByStore(findStore);
         List<Menu> menus = command.menu().stream()
-                .filter(c -> !validateMenuConflict(findStore, c.name()))
+                .filter(c -> !validateMenuConflict(allMenus, c.name()))
                 .map(c -> Menu.create(findStore, c.name(), c.price()))
                 .toList();
         menuUpdater.saveAll(menus);
@@ -69,8 +70,8 @@ public class MenuCommandService {
         findStore.updateLowestPrice(menuFinder.findLowestPriceByStore(findStore));
     }
 
-    private boolean validateMenuConflict(final Store store, final String menuName) {
-        return menuFinder.existsByStoreAndName(store, menuName);
+    private boolean validateMenuConflict(final List<Menu> menus, final String menuName) {
+        return menus.stream().anyMatch(menu -> menu.getName().equals(menuName));
     }
 
     private void checkNoMenuInStore(final Store store, final long userId) {


### PR DESCRIPTION
## Related Issue 📌
close #243 

## Description ✔️
- 본래 `validateMenuConflict`함수를 실행할 때마다 select 쿼리가 발생하던 것을, 처음부터 모든 메뉴를 가져오고(select 쿼리 1번), list에서 stream을 돌면서 판단하도록 수정했습니다.

## To Reviewers
엄청 간단한 수정 사항입니다.