### PR TITLE
[feat] 홈뷰 페이지네이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ Temporary Items
 application-local.yml
 application-dev.yml
 application-prod.yml
+application-test.yml
 
 # Qclass
 /src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/org/hankki/hankkiserver/api/common/PriceCategoryConverter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/PriceCategoryConverter.java
@@ -2,6 +2,8 @@ package org.hankki.hankkiserver.api.common;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.common.exception.BadRequestException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,10 @@ public class PriceCategoryConverter implements Converter<String, PriceCategory> 
         if (source.toUpperCase().equals(PriceCategory.ALL.toString())) {
             return null;
         }
-        return PriceCategory.valueOf(source.toUpperCase());
+        try {
+            return PriceCategory.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(StoreErrorCode.INVALID_PRICE_CATEGORY);
+        }
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
@@ -16,6 +16,5 @@ public class SortOptionConverter implements Converter<String, SortOption> {
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(StoreErrorCode.INVALID_SORT_OPTION);
         }
-
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
@@ -1,0 +1,14 @@
+package org.hankki.hankkiserver.api.common;
+
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SortOptionConverter implements Converter<String, SortOption> {
+
+    @Override
+    public SortOption convert(String source) {
+        return SortOption.valueOf(source.toUpperCase());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/SortOptionConverter.java
@@ -1,6 +1,8 @@
 package org.hankki.hankkiserver.api.common;
 
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.common.exception.BadRequestException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +11,11 @@ public class SortOptionConverter implements Converter<String, SortOption> {
 
     @Override
     public SortOption convert(String source) {
-        return SortOption.valueOf(source.toUpperCase());
+        try {
+            return SortOption.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(StoreErrorCode.INVALID_SORT_OPTION);
+        }
+
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/common/StoreCategoryConverter.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/StoreCategoryConverter.java
@@ -1,0 +1,21 @@
+package org.hankki.hankkiserver.api.common;
+
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.common.exception.BadRequestException;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoreCategoryConverter implements Converter<String, StoreCategory> {
+
+
+    @Override
+    public StoreCategory convert(String source) {
+        try {
+            return StoreCategory.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(StoreErrorCode.INVALID_STORE_CATEGORY);
+        }
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/hankki/hankkiserver/api/common/advice/GlobalExceptionHandler.java
@@ -133,7 +133,7 @@ public class GlobalExceptionHandler {
         return cause.getMessage();
     }
 
-    private static String getDefaultMessage(HandlerMethodValidationException e) {
+    private String getDefaultMessage(HandlerMethodValidationException e) {
         return e.getAllValidationResults().get(0).getResolvableErrors().get(0).getDefaultMessage();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
+++ b/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
@@ -3,11 +3,14 @@ package org.hankki.hankkiserver.api.config;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.common.PriceCategoryConverter;
+import org.hankki.hankkiserver.api.common.SortOptionConverter;
 import org.hankki.hankkiserver.api.common.UserIdArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -23,6 +26,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new PriceCategoryConverter());
+        registry.addConverter(new SortOptionConverter());
         registry.addConverter(priceCategoryConverter);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
+++ b/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
@@ -18,6 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final UserIdArgumentResolver userIdArgumentResolver;
     private final PriceCategoryConverter priceCategoryConverter;
+    private final SortOptionConverter sortOptionConverter;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -26,8 +27,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new PriceCategoryConverter());
-        registry.addConverter(new SortOptionConverter());
+        registry.addConverter(sortOptionConverter);
         registry.addConverter(priceCategoryConverter);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
+++ b/src/main/java/org/hankki/hankkiserver/api/config/WebConfig.java
@@ -1,16 +1,15 @@
 package org.hankki.hankkiserver.api.config;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.common.PriceCategoryConverter;
 import org.hankki.hankkiserver.api.common.SortOptionConverter;
+import org.hankki.hankkiserver.api.common.StoreCategoryConverter;
 import org.hankki.hankkiserver.api.common.UserIdArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Configuration
@@ -19,6 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final UserIdArgumentResolver userIdArgumentResolver;
     private final PriceCategoryConverter priceCategoryConverter;
     private final SortOptionConverter sortOptionConverter;
+    private final StoreCategoryConverter storeCategoryConverter;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -29,5 +29,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(sortOptionConverter);
         registry.addConverter(priceCategoryConverter);
+        registry.addConverter(storeCategoryConverter);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/dto/HankkiResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/dto/HankkiResponse.java
@@ -1,9 +1,14 @@
 package org.hankki.hankkiserver.api.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
 import org.hankki.hankkiserver.common.code.ErrorCode;
 import org.hankki.hankkiserver.common.code.SuccessCode;
+import org.springframework.http.HttpStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -26,5 +31,9 @@ public class HankkiResponse<T> {
 
     public static <T> HankkiResponse<T> fail(ErrorCode error) {
         return new HankkiResponse<>(error.getHttpStatus().value(), error.getMessage());
+    }
+
+    public static <T> HankkiResponse<T> fail(HttpStatus status, String message) {
+        return new HankkiResponse<>(status.value(), message);
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -34,6 +34,7 @@ import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -79,7 +80,7 @@ public class StoreController {
                                                     @RequestParam(required = false) final StoreCategory storeCategory,
                                                     @RequestParam(required = false) final PriceCategory priceCategory,
                                                     @RequestParam(required = false) final SortOption sortOption,
-                                                       @CustomCursorValidation CustomCursor cursor) {
+                                                       @ModelAttribute @CustomCursorValidation CustomCursor cursor) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoresV2(universityId, storeCategory, priceCategory, sortOption, cursor));
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package org.hankki.hankkiserver.api.store.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.common.annotation.UserId;
 import org.hankki.hankkiserver.api.dto.HankkiResponse;
 import org.hankki.hankkiserver.api.store.controller.request.StoreDuplicateValidationRequest;
 import org.hankki.hankkiserver.api.store.controller.request.StorePostRequest;
@@ -10,12 +11,35 @@ import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.HeartCommandService;
 import org.hankki.hankkiserver.api.store.service.StoreCommandService;
 import org.hankki.hankkiserver.api.store.service.StoreQueryService;
-import org.hankki.hankkiserver.api.store.service.command.*;
-import org.hankki.hankkiserver.api.store.service.response.*;
-import org.hankki.hankkiserver.api.common.annotation.UserId;
+import org.hankki.hankkiserver.api.store.service.command.HeartDeleteCommand;
+import org.hankki.hankkiserver.api.store.service.command.HeartPostCommand;
+import org.hankki.hankkiserver.api.store.service.command.StoreDeleteCommand;
+import org.hankki.hankkiserver.api.store.service.command.StorePostCommand;
+import org.hankki.hankkiserver.api.store.service.command.StoreValidationCommand;
+import org.hankki.hankkiserver.api.store.service.response.CategoriesResponse;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.hankki.hankkiserver.api.store.service.response.HeartCreateResponse;
+import org.hankki.hankkiserver.api.store.service.response.HeartDeleteResponse;
+import org.hankki.hankkiserver.api.store.service.response.PriceCategoriesResponse;
+import org.hankki.hankkiserver.api.store.service.response.SortOptionsResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoreDuplicateValidationResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoreGetResponse;
+import org.hankki.hankkiserver.api.store.service.response.StorePageResponse;
+import org.hankki.hankkiserver.api.store.service.response.StorePinsResponse;
+import org.hankki.hankkiserver.api.store.service.response.StorePostResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoreThumbnailResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoresResponse;
 import org.hankki.hankkiserver.common.code.CommonSuccessCode;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -48,19 +72,23 @@ public class StoreController {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStores(universityId, storeCategory, priceCategory, sortOption));
     }
 
+    @GetMapping("/v2/stores")
+    public HankkiResponse<StorePageResponse> getStores(@RequestParam(required = false) final Long universityId,
+                                                    @RequestParam(required = false) final StoreCategory storeCategory,
+                                                    @RequestParam(required = false) final PriceCategory priceCategory,
+                                                    @RequestParam(required = false) final SortOption sortOption,
+                                                       CustomCursor cursor) {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoresV2(universityId, storeCategory, priceCategory, sortOption, cursor));
+    }
+
     @GetMapping("/v1/stores/{id}/thumbnail")
     public HankkiResponse<StoreThumbnailResponse> getStoreThumbnail(@PathVariable final Long id) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoreThumbnail(id));
     }
 
     @GetMapping("/v1/stores/categories")
-    public HankkiResponse<CategoriesResponse> getCategoriesV1() {
-        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategoriesV1());
-    }
-
-    @GetMapping("/v2/stores/categories")
-    public HankkiResponse<CategoriesResponse> getCategoriesV2() {
-        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategoriesV2());
+    public HankkiResponse<CategoriesResponse> getCategories() {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategories());
     }
 
     @GetMapping("/v1/stores/sort-options")

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -1,7 +1,6 @@
 package org.hankki.hankkiserver.api.store.controller;
 
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.common.annotation.UserId;
 import org.hankki.hankkiserver.api.dto.HankkiResponse;
 import org.hankki.hankkiserver.api.store.controller.request.StoreDuplicateValidationRequest;
@@ -29,8 +28,10 @@ import org.hankki.hankkiserver.api.store.service.response.StorePinsResponse;
 import org.hankki.hankkiserver.api.store.service.response.StorePostResponse;
 import org.hankki.hankkiserver.api.store.service.response.StoreThumbnailResponse;
 import org.hankki.hankkiserver.api.store.service.response.StoresResponse;
+import org.hankki.hankkiserver.api.store.support.CustomCursorValidation;
 import org.hankki.hankkiserver.common.code.CommonSuccessCode;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -77,7 +79,7 @@ public class StoreController {
                                                     @RequestParam(required = false) final StoreCategory storeCategory,
                                                     @RequestParam(required = false) final PriceCategory priceCategory,
                                                     @RequestParam(required = false) final SortOption sortOption,
-                                                       CustomCursor cursor) {
+                                                       @Validated @CustomCursorValidation CustomCursor cursor) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoresV2(universityId, storeCategory, priceCategory, sortOption, cursor));
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -87,8 +87,13 @@ public class StoreController {
     }
 
     @GetMapping("/v1/stores/categories")
-    public HankkiResponse<CategoriesResponse> getCategories() {
-        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategories());
+    public HankkiResponse<CategoriesResponse> getCategoriesV1() {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategoriesV1());
+    }
+
+    @GetMapping("/v2/stores/categories")
+    public HankkiResponse<CategoriesResponse> getCategoriesV2() {
+        return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getCategoriesV2());
     }
 
     @GetMapping("/v1/stores/sort-options")

--- a/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/controller/StoreController.java
@@ -79,7 +79,7 @@ public class StoreController {
                                                     @RequestParam(required = false) final StoreCategory storeCategory,
                                                     @RequestParam(required = false) final PriceCategory priceCategory,
                                                     @RequestParam(required = false) final SortOption sortOption,
-                                                       @Validated @CustomCursorValidation CustomCursor cursor) {
+                                                       @CustomCursorValidation CustomCursor cursor) {
         return HankkiResponse.success(CommonSuccessCode.OK, storeQueryService.getStoresV2(universityId, storeCategory, priceCategory, sortOption, cursor));
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -1,5 +1,6 @@
 package org.hankki.hankkiserver.api.store.service;
 
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
@@ -38,11 +39,15 @@ public class StoreFinder {
         return storeRepository.existsByPoint_LatitudeAndPoint_LongitudeAndNameAndIsDeleted(latitude, longitude, name, isDeleted);
     }
 
-    public List<Store> findAllDynamicQuery(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
-        return storeRepository.findStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(storeCategory, priceCategory, universityId, sortOption);
+    public List<Store> findAllWithUniversityStoreByDynamicQuery(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
+        return storeRepository.findStoreWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption);
     }
 
     public List<Store> findAllByFavoriteStoresAndDeletedIsFalseOrderByFavoriteStoreId(final List<FavoriteStore> favoriteStores) {
         return storeRepository.findAllByFavoriteStoresAndIsDeletedIsFalseOrderByFavoriteStoreId(favoriteStores);
+    }
+
+    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption) {
+        return null;
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -42,8 +42,8 @@ public class StoreFinder {
         return storeRepository.findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(storeCategory, priceCategory, universityId, sortOption);
     }
 
-    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption, CustomCursor cursor) {
-        return storeRepository.findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, sortOption, cursor);
+    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption, CustomCursor cursor, int PAGE_SIZE) {
+        return storeRepository.findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, sortOption, cursor, PAGE_SIZE);
 
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -1,9 +1,11 @@
 package org.hankki.hankkiserver.api.store.service;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.common.code.StoreErrorCode;
 import org.hankki.hankkiserver.common.exception.NotFoundException;
 import org.hankki.hankkiserver.domain.favoritestore.model.FavoriteStore;
@@ -11,9 +13,6 @@ import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.store.repository.StoreRepository;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -40,14 +39,15 @@ public class StoreFinder {
     }
 
     public List<Store> findAllWithUniversityStoreByDynamicQuery(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
-        return storeRepository.findStoreWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption);
+        return storeRepository.findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(storeCategory, priceCategory, universityId, sortOption);
+    }
+
+    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption, CustomCursor cursor) {
+        return storeRepository.findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, sortOption, cursor);
+
     }
 
     public List<Store> findAllByFavoriteStoresAndDeletedIsFalseOrderByFavoriteStoreId(final List<FavoriteStore> favoriteStores) {
         return storeRepository.findAllByFavoriteStoresAndIsDeletedIsFalseOrderByFavoriteStoreId(favoriteStores);
-    }
-
-    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption) {
-        return null;
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -2,7 +2,6 @@ package org.hankki.hankkiserver.api.store.service;
 
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
@@ -13,6 +12,7 @@ import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.store.repository.StoreRepository;
 import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreFinder.java
@@ -42,8 +42,8 @@ public class StoreFinder {
         return storeRepository.findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(storeCategory, priceCategory, universityId, sortOption);
     }
 
-    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption, CustomCursor cursor, int PAGE_SIZE) {
-        return storeRepository.findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, sortOption, cursor, PAGE_SIZE);
+    public List<Store> findAllByDynamicQueryWithPaging(StoreCategory storeCategory, PriceCategory priceCategory, SortOption sortOption, CustomCursor cursor, int limitSize) {
+        return storeRepository.findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, sortOption, cursor, limitSize);
 
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -89,7 +89,7 @@ public class StoreQueryService {
     }
 
     private <T>boolean isNextPageAvailable(List<T> elements) {
-        return elements.size() == 10;
+        return elements.size() == PAGE_SIZE;
     }
 
     public CategoriesResponse getCategoriesV1() {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -3,8 +3,6 @@ package org.hankki.hankkiserver.api.store.service;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.hankki.hankkiserver.api.menu.service.MenuFinder;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
@@ -32,6 +30,8 @@ import org.hankki.hankkiserver.domain.store.model.StoreImage;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/StoreQueryService.java
@@ -45,13 +45,18 @@ public class StoreQueryService {
 
     @Transactional(readOnly = true)
     public StorePinsResponse getStorePins(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
-        return StorePinsResponse.of(storeFinder.findAllDynamicQuery(universityId, storeCategory, priceCategory, sortOption)
+        return StorePinsResponse.of(storeFinder.findAllWithUniversityStoreByDynamicQuery(universityId, storeCategory, priceCategory, sortOption)
                 .stream().map(PinResponse::of).toList());
     }
 
     @Transactional(readOnly = true)
     public StoresResponse getStores(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
-        return StoresResponse.of(storeFinder.findAllDynamicQuery(universityId, storeCategory, priceCategory, sortOption)
+        if (universityId == null) {
+            return StoresResponse.of(storeFinder.findAllByDynamicQueryWithPaging(storeCategory, priceCategory, sortOption)
+                    .stream().map(StoreResponse::of).toList());
+        }
+        //중간테이블 기준으로 갖고옴
+        return StoresResponse.of(universityStoreFinder.findAllWithStoreByDynamicQueryWithPaging(universityId, storeCategory, priceCategory, sortOption)
                 .stream().map(StoreResponse::of).toList());
     }
 

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
@@ -22,8 +22,8 @@ public class UniversityStoreFinder {
                                                                           final PriceCategory priceCategory,
                                                                           final SortOption sortOption,
                                                                           final CustomCursor cursor,
-                                                                          final int PAGE_SIZE) {
-        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption, cursor, PAGE_SIZE);
+                                                                          final int limitSize) {
+        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption, cursor, limitSize);
     }
 
     protected boolean existsByUniversityIdAndStore(final Long universityId, final Store store) {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
@@ -16,8 +17,12 @@ public class UniversityStoreFinder {
 
     private final UniversityStoreRepository universityStoreRepository;
 
-    public List<UniversityStore> findAllWithStoreByDynamicQueryWithPaging(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
-        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption);
+    public List<UniversityStore> findAllWithStoreByDynamicQueryWithPaging(final Long universityId,
+                                                                          final StoreCategory storeCategory,
+                                                                          final PriceCategory priceCategory,
+                                                                          final SortOption sortOption,
+                                                                          final CustomCursor cursor) {
+        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption, cursor);
     }
 
     protected boolean existsByUniversityIdAndStore(final Long universityId, final Store store) {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
@@ -1,7 +1,6 @@
 package org.hankki.hankkiserver.api.store.service;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
@@ -10,6 +9,7 @@ import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.hankki.hankkiserver.domain.universitystore.repository.UniversityStoreRepository;
 import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
@@ -1,7 +1,12 @@
 package org.hankki.hankkiserver.api.store.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.hankki.hankkiserver.domain.universitystore.repository.UniversityStoreRepository;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +15,10 @@ import org.springframework.stereotype.Component;
 public class UniversityStoreFinder {
 
     private final UniversityStoreRepository universityStoreRepository;
+
+    public List<UniversityStore> findAllWithStoreByDynamicQueryWithPaging(final Long universityId, final StoreCategory storeCategory, final PriceCategory priceCategory, final SortOption sortOption) {
+        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption);
+    }
 
     protected boolean existsByUniversityIdAndStore(final Long universityId, final Store store) {
         return universityStoreRepository.existsByUniversityIdAndStore(universityId, store);

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/UniversityStoreFinder.java
@@ -21,8 +21,9 @@ public class UniversityStoreFinder {
                                                                           final StoreCategory storeCategory,
                                                                           final PriceCategory priceCategory,
                                                                           final SortOption sortOption,
-                                                                          final CustomCursor cursor) {
-        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption, cursor);
+                                                                          final CustomCursor cursor,
+                                                                          final int PAGE_SIZE) {
+        return universityStoreRepository.findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(storeCategory, priceCategory, universityId, sortOption, cursor, PAGE_SIZE);
     }
 
     protected boolean existsByUniversityIdAndStore(final Long universityId, final Store store) {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
@@ -1,6 +1,8 @@
 package org.hankki.hankkiserver.api.store.service.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.domain.store.model.Store;
 
 public record CustomCursor(
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -10,8 +12,38 @@ public record CustomCursor(
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Integer nextHeartCount) {
 
+    public static CustomCursor createNextCursor(SortOption sortOption, Store store) {
+
+        if (sortOption == null) {
+            return CustomCursor.builder()
+                    .nextId(store.getId())
+                    .build();
+        }
+
+        switch (sortOption) {
+            case RECOMMENDED -> {
+                return CustomCursor.builder()
+                        .nextId(store.getId())
+                        .nextHeartCount(store.getHearts().size())
+                        .build();
+            }
+            case LOWESTPRICE -> {
+                return CustomCursor.builder()
+                        .nextId(store.getId())
+                        .nextLowestPrice(store.getLowestPrice())
+                        .build();
+            }
+            default -> {
+                return CustomCursor.builder()
+                        .nextId(store.getId())
+                        .build();
+            }
+        }
+    }
+
     public static CustomCursorBuilder builder() {
         return new CustomCursorBuilder();
+
     }
 
     public static class CustomCursorBuilder {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
@@ -1,0 +1,41 @@
+package org.hankki.hankkiserver.api.store.service.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record CustomCursor(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Long nextId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Integer nextLowestPrice,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Integer nextHeartCount) {
+
+    public static CustomCursorBuilder builder() {
+        return new CustomCursorBuilder();
+    }
+
+    public static class CustomCursorBuilder {
+        private Long nextId;
+        private Integer nextLowestPrice;
+        private Integer nextHeartCount;
+
+        public CustomCursorBuilder nextId(Long nextId) {
+            this.nextId = nextId;
+            return this;
+        }
+
+        public CustomCursorBuilder nextLowestPrice(Integer nextLowestPrice) {
+            this.nextLowestPrice = nextLowestPrice;
+            return this;
+        }
+
+        public CustomCursorBuilder nextHeartCount(Integer nextHeartCount) {
+            this.nextHeartCount = nextHeartCount;
+            return this;
+        }
+
+        public CustomCursor build() {
+            return new CustomCursor(nextId, nextLowestPrice, nextHeartCount);
+        }
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
@@ -1,8 +1,8 @@
 package org.hankki.hankkiserver.api.store.service.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.domain.store.model.Store;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public record CustomCursor(
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
@@ -41,12 +41,12 @@ public record CustomCursor(
         }
     }
 
-    public static CustomCursorBuilder builder() {
+    private static CustomCursorBuilder builder() {
         return new CustomCursorBuilder();
 
     }
 
-    public static class CustomCursorBuilder {
+    private static class CustomCursorBuilder {
         private Long nextId;
         private Integer nextLowestPrice;
         private Integer nextHeartCount;

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/CustomCursor.java
@@ -24,7 +24,7 @@ public record CustomCursor(
             case RECOMMENDED -> {
                 return CustomCursor.builder()
                         .nextId(store.getId())
-                        .nextHeartCount(store.getHearts().size())
+                        .nextHeartCount(store.getHeartCount())
                         .build();
             }
             case LOWESTPRICE -> {

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StorePageResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StorePageResponse.java
@@ -1,0 +1,13 @@
+package org.hankki.hankkiserver.api.store.service.response;
+
+import java.util.List;
+
+public record StorePageResponse(
+        List<StoreResponse> stores,
+        boolean hasNext,
+        CustomCursor cursor) {
+
+    public static StorePageResponse of(final List<StoreResponse> stores, final boolean hasNext, final CustomCursor cursor) {
+        return new StorePageResponse(stores, hasNext, cursor);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreResponse.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/service/response/StoreResponse.java
@@ -1,6 +1,7 @@
 package org.hankki.hankkiserver.api.store.service.response;
 
 import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 
 public record StoreResponse (
         long id,
@@ -17,5 +18,14 @@ public record StoreResponse (
                 store.getName(),
                 store.getLowestPrice(),
                 store.getHeartCount());
+    }
+
+    public static StoreResponse of(final UniversityStore universityStore) {
+        return new StoreResponse(universityStore.getStore().getId(),
+                universityStore.getStore().getImages().isEmpty() ? null : universityStore.getStore().getImages().get(0).getImageUrl(),
+                universityStore.getStore().getCategory().getName(),
+                universityStore.getStore().getName(),
+                universityStore.getStore().getLowestPrice(),
+                universityStore.getStore().getHeartCount());
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/api/store/support/CustomCursorValidation.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/support/CustomCursorValidation.java
@@ -1,0 +1,18 @@
+package org.hankki.hankkiserver.api.store.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Constraint(validatedBy = CustomCursorValidator.class)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomCursorValidation {
+    String message() default "cursor 값이 SortOption에 맞지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/org/hankki/hankkiserver/api/store/support/CustomCursorValidator.java
+++ b/src/main/java/org/hankki/hankkiserver/api/store/support/CustomCursorValidator.java
@@ -1,0 +1,53 @@
+package org.hankki.hankkiserver.api.store.support;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import io.micrometer.observation.annotation.Observed;
+
+public class CustomCursorValidator implements ConstraintValidator<CustomCursorValidation, CustomCursor> {
+
+    @Override
+    public void initialize(CustomCursorValidation constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(CustomCursor cursor, ConstraintValidatorContext context) {
+        if (cursor == null) {
+            return true;
+        }
+
+        SortOption sortOption = getSortOptionFromRequest();
+        if (sortOption == null) {
+            return true;
+        }
+
+        boolean isValid = switch(sortOption)  {
+            case RECOMMENDED -> cursor.nextHeartCount() != null && cursor.nextId() != null;
+            case LOWESTPRICE -> cursor.nextLowestPrice() != null && cursor.nextId() != null;
+            case LATEST -> cursor.nextHeartCount() == null && cursor.nextLowestPrice() == null;
+        };
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(StoreErrorCode.BAD_CURSOR_SET.getMessage())
+                    .addConstraintViolation();
+        }
+        return isValid;
+    }
+
+    private SortOption getSortOptionFromRequest() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            HttpServletRequest request = attributes.getRequest();
+            String sortOption = request.getParameter("sortOption");
+            return sortOption != null ? SortOption.valueOf(sortOption.toUpperCase()) : null;
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/auth/config/SecurityConfig.java
+++ b/src/main/java/org/hankki/hankkiserver/auth/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
 
     private static final String[] authWhiteList = {"/api/v1/auth/login", "/api/v1/auth/reissue", "/actuator/health"};
     private static final String[] businessLogicWhileList = {"/api/v1/stores/categories", "/api/v1/stores/sort-options", "/api/v1/stores/price-categories",
-    "/api/v1/stores", "/api/v1/stores/pins", "/api/v1/stores/{articleId:\\d+}/thumbnail", "/api/v1/universities", "/api/v1/favorites/shared/{favoriteId:\\d+}"};
+    "/api/v1/stores", "/api/v2/stores" ,"/api/v1/stores/pins", "/api/v1/stores/{articleId:\\d+}/thumbnail", "/api/v1/universities", "/api/v1/favorites/shared/{favoriteId:\\d+}"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/org/hankki/hankkiserver/common/code/StoreErrorCode.java
+++ b/src/main/java/org/hankki/hankkiserver/common/code/StoreErrorCode.java
@@ -10,7 +10,11 @@ public enum StoreErrorCode implements ErrorCode {
 
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
     STORE_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 초과되었습니다."),
-    BAD_STORE_INFO(HttpStatus.BAD_REQUEST, "잘못된 식당 정보입니다.");
+    BAD_STORE_INFO(HttpStatus.BAD_REQUEST, "잘못된 식당 정보입니다."),
+    BAD_CURSOR_SET(HttpStatus.BAD_REQUEST, "cursor 값이 SortOption에 맞지 않습니다."),
+    INVALID_PRICE_CATEGORY(HttpStatus.BAD_REQUEST, "price category가 맞지 않습니다."),
+    INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "정렬 옵션이 맞지 않습니다."),
+    INVALID_STORE_CATEGORY(HttpStatus.BAD_REQUEST, "store category가 맞지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CursorProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CursorProvider.java
@@ -1,0 +1,45 @@
+package org.hankki.hankkiserver.domain.store.repository;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CursorProvider {
+    public BooleanExpression createCursorCondition(CustomCursor cursor, SortOption sortOptions) {
+        if (sortOptions == null) {
+            return createCursorWhenSortByLatest(cursor);
+        }
+        return switch (sortOptions) {
+            case LATEST -> createCursorWhenSortByLatest(cursor);
+            case LOWESTPRICE -> createCursorWhenSortByLowestPrice(cursor);
+            case RECOMMENDED -> createCursorWhenSortByRecommended(cursor);
+        };
+    }
+
+    private  BooleanExpression createCursorWhenSortByRecommended(CustomCursor cursor) {
+        if (cursor.nextId() == null || cursor.nextHeartCount() == null) {
+            return null;
+        }
+        return store.heartCount.lt(cursor.nextHeartCount())
+                .or(store.id.lt(cursor.nextId()).and(store.heartCount.eq(cursor.nextHeartCount())));
+    }
+
+    private BooleanExpression createCursorWhenSortByLowestPrice(CustomCursor cursor) {
+        if (cursor.nextId() == null || cursor.nextLowestPrice() == null) {
+            return null;
+        }
+        return store.lowestPrice.gt(cursor.nextLowestPrice())
+                .or(store.id.lt(cursor.nextId()).and(store.lowestPrice.eq(cursor.nextLowestPrice())));
+    }
+
+    private  BooleanExpression createCursorWhenSortByLatest(CustomCursor cursor) {
+        if (cursor.nextId() == null) {
+            return null;
+        }
+        return store.id.lt(cursor.nextId());
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
@@ -9,6 +9,6 @@ import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 
 public interface CustomStoreRepository {
     List<Store> findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
-    List<Store> findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE);
+    List<Store> findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, SortOption sortOptions, CustomCursor cursor, int limitSize);
 
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
@@ -8,5 +8,5 @@ import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import java.util.List;
 
 public interface CustomStoreRepository {
-    List<Store> findStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
+    List<Store> findStoreWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
@@ -2,11 +2,14 @@ package org.hankki.hankkiserver.domain.store.repository;
 
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 
 import java.util.List;
 
 public interface CustomStoreRepository {
-    List<Store> findStoreWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
+    List<Store> findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
+    List<Store> findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, SortOption sortOptions, CustomCursor cursor);
+
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
@@ -10,6 +10,6 @@ import java.util.List;
 
 public interface CustomStoreRepository {
     List<Store> findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
-    List<Store> findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, SortOption sortOptions, CustomCursor cursor);
+    List<Store> findAllByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(StoreCategory category, PriceCategory priceCategory, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE);
 
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepository.java
@@ -1,12 +1,11 @@
 package org.hankki.hankkiserver.domain.store.repository;
 
+import java.util.List;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
-
-import java.util.List;
 
 public interface CustomStoreRepository {
     List<Store> findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -3,7 +3,6 @@ package org.hankki.hankkiserver.domain.store.repository;
 import static org.hankki.hankkiserver.domain.store.model.QStore.store;
 import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     private final JPAQueryFactory jpaQueryFactory;
     private final OrderSpecifierProvider orderSpecifierProvider;
     private final CursorProvider cursorProvider;
+    private final DynamicQueryProvider dynamicQueryProvider;
 
     @Override
     public List<Store> findAllWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(
@@ -33,7 +33,9 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 .select(store)
                 .from(store)
                 .join(store.universityStores, universityStore).fetchJoin()
-                .where(eqCategory(category),eqUniversity(universityId), evaluatePriceCategory(priceCategory))
+                .where(dynamicQueryProvider.eqCategory(category),
+                        dynamicQueryProvider.hasUniversity(universityId),
+                        dynamicQueryProvider.evaluatePriceCategory(priceCategory))
                 .where(store.isDeleted.isFalse())
                 .orderBy(orderSpecifierProvider.createOrderSpecifier(sortOptions))
                 .fetch();
@@ -49,32 +51,11 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 .select(store)
                 .from(store)
                 .where(cursorProvider.createCursorCondition(cursor, sortOptions))
-                .where(eqCategory(category), evaluatePriceCategory(priceCategory)) // 필터
+                .where(dynamicQueryProvider.eqCategory(category),
+                        dynamicQueryProvider.evaluatePriceCategory(priceCategory)) // 필터
                 .where(store.isDeleted.isFalse())
                 .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))//정렬
                 .limit(PAGE_SIZE)
                 .fetch();
-    }
-
-    private BooleanExpression eqUniversity(Long university) {
-        if (university == null) {
-            return null;
-        }
-        return store.universityStores.any().university.id.eq(university);
-    }
-
-    private BooleanExpression eqCategory(StoreCategory category) {
-        if (category == null) {
-            return null;
-        }
-        return store.category.eq(category);
-    }
-
-    private BooleanExpression evaluatePriceCategory(PriceCategory priceCategory) {
-        if (priceCategory == null) {
-            return null;
-        }
-        return store.lowestPrice.goe(priceCategory.getMinPrice())
-                .and(store.lowestPrice.loe(priceCategory.getMaxPrice()));
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -23,8 +23,14 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Store> findStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptions(StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions) {
+    public List<Store> findStoreWithUniversityStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
+            StoreCategory category,
+            PriceCategory priceCategory,
+            Long universityId,
+            SortOption sortOptions) {
+
         OrderSpecifier[] orderSpecifiers = createOrderSpecifier(sortOptions);
+        //이거 쿼리 문제점 대학 필터 없을 때 조인 필요없는데 조인 돼서 나감
         return jpaQueryFactory
                 .select(store)
                 .from(store)

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -1,17 +1,17 @@
 package org.hankki.hankkiserver.domain.store.repository;
 
-import static org.hankki.hankkiserver.domain.store.model.QStore.store;
-import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.springframework.stereotype.Component;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -45,7 +45,7 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
             PriceCategory priceCategory,
             SortOption sortOptions,
             CustomCursor cursor,
-            int PAGE_SIZE) {
+            int limitSize) {
         return jpaQueryFactory
                 .select(store)
                 .from(store)
@@ -57,7 +57,7 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 .where(store.isDeleted.isFalse())
                 // 정렬
                 .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))
-                .limit(PAGE_SIZE)
+                .limit(limitSize)
                 .fetch();
     }
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -16,8 +16,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CustomStoreRepositoryImpl implements CustomStoreRepository {
-    private static final int PAGE_SIZE = 10;
-
     private final JPAQueryFactory jpaQueryFactory;
     private final OrderSpecifierProvider orderSpecifierProvider;
     private final CursorProvider cursorProvider;
@@ -46,15 +44,19 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
             StoreCategory category,
             PriceCategory priceCategory,
             SortOption sortOptions,
-            CustomCursor cursor) {
+            CustomCursor cursor,
+            int PAGE_SIZE) {
         return jpaQueryFactory
                 .select(store)
                 .from(store)
+                // 커서
                 .where(cursorProvider.createCursorCondition(cursor, sortOptions))
+                // 필터
                 .where(dynamicQueryProvider.eqCategory(category),
-                        dynamicQueryProvider.evaluatePriceCategory(priceCategory)) // 필터
+                        dynamicQueryProvider.evaluatePriceCategory(priceCategory))
                 .where(store.isDeleted.isFalse())
-                .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))//정렬
+                // 정렬
+                .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))
                 .limit(PAGE_SIZE)
                 .fetch();
     }

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/DynamicQueryProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/DynamicQueryProvider.java
@@ -1,0 +1,43 @@
+package org.hankki.hankkiserver.domain.store.repository;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DynamicQueryProvider {
+
+    public BooleanExpression hasUniversity(Long university) {
+        if (university == null) {
+            return null;
+        }
+        return store.universityStores.any().university.id.eq(university);
+    }
+
+    public BooleanExpression eqCategory(StoreCategory category) {
+        if (category == null) {
+            return null;
+        }
+        return store.category.eq(category);
+    }
+
+    public BooleanExpression evaluatePriceCategory(PriceCategory priceCategory) {
+        if (priceCategory == null) {
+            return null;
+        }
+        return store.lowestPrice.goe(priceCategory.getMinPrice())
+                .and(store.lowestPrice.loe(priceCategory.getMaxPrice()));
+    }
+
+    public BooleanExpression eqUniversity(Long university) {
+        if (university == null) {
+            return null;
+        }
+        return universityStore.university.id.eq(university);
+    }
+
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/DynamicQueryProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/DynamicQueryProvider.java
@@ -26,7 +26,7 @@ public class DynamicQueryProvider {
     }
 
     public BooleanExpression evaluatePriceCategory(PriceCategory priceCategory) {
-        if (priceCategory == null) {
+        if (priceCategory == null || priceCategory == PriceCategory.ALL) {
             return null;
         }
         return store.lowestPrice.goe(priceCategory.getMinPrice())

--- a/src/main/java/org/hankki/hankkiserver/domain/store/repository/OrderSpecifierProvider.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/store/repository/OrderSpecifierProvider.java
@@ -1,0 +1,51 @@
+package org.hankki.hankkiserver.domain.store.repository;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderSpecifierProvider {
+    public OrderSpecifier[] createOrderSpecifier(SortOption sortOption) {
+
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+        if (Objects.isNull(sortOption)){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        else if (SortOption.LATEST == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        else if (SortOption.LOWESTPRICE == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, store.lowestPrice));
+        }
+        else if (SortOption.RECOMMENDED == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.heartCount));
+        }
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+    }
+
+    public OrderSpecifier[] createOrderSpecifierForPaging(SortOption sortOption) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+        if (Objects.isNull(sortOption)){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        else if (SortOption.LATEST == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        else if (SortOption.LOWESTPRICE == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, store.lowestPrice));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        else if (SortOption.RECOMMENDED == sortOption){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.heartCount));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, store.id));
+        }
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+    }
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
@@ -9,5 +9,5 @@ import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 
 public interface CustomUniversityStoreRepository {
     List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
-            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor);
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
@@ -1,0 +1,12 @@
+package org.hankki.hankkiserver.domain.universitystore.repository;
+
+import java.util.List;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
+
+public interface CustomUniversityStoreRepository {
+    List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
+}

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
@@ -3,10 +3,11 @@ package org.hankki.hankkiserver.domain.universitystore.repository;
 import java.util.List;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
 import org.hankki.hankkiserver.domain.store.model.StoreCategory;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 
 public interface CustomUniversityStoreRepository {
     List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
-            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions);
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepository.java
@@ -9,5 +9,5 @@ import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 
 public interface CustomUniversityStoreRepository {
     List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
-            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE);
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int limitSize);
 }

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CustomUniversityStoreRepositoryImpl implements CustomUniversityStoreRepository {
-    private static final int PAGE_SIZE = 10;
 
     private final JPAQueryFactory jpaQueryFactory;
     private final OrderSpecifierProvider orderSpecifierProvider;
@@ -27,7 +26,7 @@ public class CustomUniversityStoreRepositoryImpl implements CustomUniversityStor
     private final DynamicQueryProvider dynamicQueryProvider;
     @Override
     public List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
-            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor) {
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE) {
         return jpaQueryFactory
                 .select(universityStore)
                 .from(universityStore)

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CustomUniversityStoreRepositoryImpl implements CustomUniversityStor
     private final DynamicQueryProvider dynamicQueryProvider;
     @Override
     public List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
-            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int PAGE_SIZE) {
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor, int limitSize) {
         return jpaQueryFactory
                 .select(universityStore)
                 .from(universityStore)
@@ -37,7 +37,7 @@ public class CustomUniversityStoreRepositoryImpl implements CustomUniversityStor
                         dynamicQueryProvider.evaluatePriceCategory(priceCategory))
                 .where(universityStore.store.isDeleted.isFalse())
                 .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))
-                .limit(PAGE_SIZE)
+                .limit(limitSize)
                 .fetch();
     }
  }

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
@@ -1,11 +1,6 @@
 package org.hankki.hankkiserver.domain.universitystore.repository;
 
-import static org.hankki.hankkiserver.domain.store.model.QStore.store;
-import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
 import org.hankki.hankkiserver.api.store.parameter.SortOption;
 import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
@@ -15,6 +10,11 @@ import org.hankki.hankkiserver.domain.store.repository.DynamicQueryProvider;
 import org.hankki.hankkiserver.domain.store.repository.OrderSpecifierProvider;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.springframework.stereotype.Component;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/CustomUniversityStoreRepositoryImpl.java
@@ -1,0 +1,45 @@
+package org.hankki.hankkiserver.domain.universitystore.repository;
+
+import static org.hankki.hankkiserver.domain.store.model.QStore.store;
+import static org.hankki.hankkiserver.domain.universitystore.model.QUniversityStore.universityStore;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.domain.store.repository.CursorProvider;
+import org.hankki.hankkiserver.domain.store.repository.DynamicQueryProvider;
+import org.hankki.hankkiserver.domain.store.repository.OrderSpecifierProvider;
+import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomUniversityStoreRepositoryImpl implements CustomUniversityStoreRepository {
+    private static final int PAGE_SIZE = 10;
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final OrderSpecifierProvider orderSpecifierProvider;
+    private final CursorProvider cursorProvider;
+    private final DynamicQueryProvider dynamicQueryProvider;
+    @Override
+    public List<UniversityStore> findAllWithStoreByCategoryAndLowestPriceAndUniversityIdAndIsDeletedFalseOrderBySortOptionsWithPaging(
+            StoreCategory category, PriceCategory priceCategory, Long universityId, SortOption sortOptions, CustomCursor cursor) {
+        return jpaQueryFactory
+                .select(universityStore)
+                .from(universityStore)
+                .join(universityStore.store, store).fetchJoin()
+                .where(cursorProvider.createCursorCondition(cursor, sortOptions))
+                .where(dynamicQueryProvider.eqUniversity(universityId),
+                        dynamicQueryProvider.eqCategory(category),
+                        dynamicQueryProvider.evaluatePriceCategory(priceCategory))
+                .where(universityStore.store.isDeleted.isFalse())
+                .orderBy(orderSpecifierProvider.createOrderSpecifierForPaging(sortOptions))
+                .limit(PAGE_SIZE)
+                .fetch();
+    }
+ }
+

--- a/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/UniversityStoreRepository.java
+++ b/src/main/java/org/hankki/hankkiserver/domain/universitystore/repository/UniversityStoreRepository.java
@@ -4,7 +4,8 @@ import org.hankki.hankkiserver.domain.store.model.Store;
 import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UniversityStoreRepository extends JpaRepository<UniversityStore, Long> {
+public interface UniversityStoreRepository extends JpaRepository<UniversityStore, Long>, CustomUniversityStoreRepository {
 
     boolean existsByUniversityIdAndStore(Long universityId, Store store);
+
 }

--- a/src/test/java/org/hankki/hankkiserver/HankkiserverApplicationTests.java
+++ b/src/test/java/org/hankki/hankkiserver/HankkiserverApplicationTests.java
@@ -2,8 +2,10 @@ package org.hankki.hankkiserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class HankkiserverApplicationTests {
 
 	@Test

--- a/src/test/java/org/hankki/hankkiserver/ServiceSliceTest.java
+++ b/src/test/java/org/hankki/hankkiserver/ServiceSliceTest.java
@@ -1,0 +1,14 @@
+package org.hankki.hankkiserver;
+
+import org.hankki.hankkiserver.util.DatabaseCleanerExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@ActiveProfiles("test")
+public abstract class ServiceSliceTest {
+}
+

--- a/src/test/java/org/hankki/hankkiserver/api/common/PriceCategoryConverterTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/common/PriceCategoryConverterTest.java
@@ -1,0 +1,18 @@
+package org.hankki.hankkiserver.api.common;
+
+import org.assertj.core.api.Assertions;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PriceCategoryConverterTest {
+
+    @Test
+    @DisplayName("가격 카테고리로 전체를 넘겨주면 아무것도 매핑하지 않는다")
+    void convertCategoryAll() {
+        PriceCategoryConverter priceCategoryConverter = new PriceCategoryConverter();
+        String priceCategory = "ALL";
+        PriceCategory result = priceCategoryConverter.convert(priceCategory);
+        Assertions.assertThat(result).isNull();
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/api/common/StoreCategoryConverterTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/common/StoreCategoryConverterTest.java
@@ -1,0 +1,15 @@
+package org.hankki.hankkiserver.api.common;
+
+import org.assertj.core.api.Assertions;
+import org.hankki.hankkiserver.common.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+class StoreCategoryConverterTest {
+
+    @Test
+    void convertToEntityAttribute() {
+        StoreCategoryConverter storeCategoryConverter = new StoreCategoryConverter();
+        String storeCategory = "ㅁㅁㅁ";
+        Assertions.assertThatThrownBy(() -> storeCategoryConverter.convert(storeCategory)).isInstanceOf(BadRequestException.class);
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/api/store/controller/StoreControllerTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/store/controller/StoreControllerTest.java
@@ -1,0 +1,114 @@
+package org.hankki.hankkiserver.api.store.controller;
+
+import java.util.List;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.HeartCommandService;
+import org.hankki.hankkiserver.api.store.service.StoreCommandService;
+import org.hankki.hankkiserver.api.store.service.StoreQueryService;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.hankki.hankkiserver.api.store.service.response.StorePageResponse;
+import org.hankki.hankkiserver.api.store.service.response.StoreResponse;
+import org.hankki.hankkiserver.auth.config.SecurityConfig;
+import org.hankki.hankkiserver.common.code.StoreErrorCode;
+import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.fixture.StoreFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = StoreController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+class StoreControllerTest {
+
+    @MockBean
+    private StoreCommandService storeCommandService;
+    @MockBean
+    private StoreQueryService storeQueryService;
+    @MockBean
+    private HeartCommandService heartCommandService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("정상적인 파라미터로 조회시, 페이징된 결과를 반환한다.")
+    void getStoresWithInvalidCursor() throws Exception {
+        Store store = StoreFixture.create("name", StoreCategory.KOREAN, 3000, 6000);
+        StorePageResponse storePageResponse = StorePageResponse.of(List.of(new StoreResponse(1, "imageUrl", StoreCategory.KOREAN.getName(), "name", 3000, 6000)),
+                false,
+                CustomCursor.createNextCursor(SortOption.LOWESTPRICE, store));
+
+        when(storeQueryService.getStoresV2(any(), any(), any(), any(), any()))
+                .thenReturn(storePageResponse);
+
+        mockMvc.perform(get("/api/v2/stores")
+                        .param("storeCategory", "KOREAN")
+                        .param("priceCategory", "K8")
+                        .param("sortOption", "LOWESTPRICE")
+                        .param("nextId", "10")
+                        .param("nextLowestPrice", "6000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.stores[0].name").value(store.getName()))
+                .andExpect(jsonPath("$.data.stores[0].lowestPrice").value(store.getLowestPrice()))
+                .andExpect(jsonPath("$.data.stores[0].heartCount").value(store.getHeartCount()))
+                .andExpect(jsonPath("$.data.stores[0].category").value(store.getCategory().getName()));
+
+    }
+    @Test
+    @DisplayName("정렬 옵션에 맞지 않는 커서로 요청하면 실패한다")
+    void failGetStoresWithInvalidCursor() throws Exception {
+        mockMvc.perform(get("/api/v2/stores")
+                        .param("storeCategory", "KOREAN")
+                        .param("priceCategory", "K8")
+                        .param("sortOption", "LOWESTPRICE")
+                        .param("nextLowestPrice", "6000"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(StoreErrorCode.BAD_CURSOR_SET.getMessage()));
+
+    }
+
+    @Test
+    @DisplayName("옳바른 카테고리 필터값을 주지 않으면 실패한다.")
+    void failGetStoresWithInvalidCategoryOption() throws Exception {
+        mockMvc.perform(get("/api/v2/stores")
+                        .param("storeCategory", "aa"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(StoreErrorCode.INVALID_STORE_CATEGORY.getMessage()));
+    }
+
+    @Test
+    @DisplayName("옳바른 가격대 필터값을 주지 않으면 실패한다.")
+    void failGetStoresWithInvalidPriceOption() throws Exception {
+        mockMvc.perform(get("/api/v2/stores")
+                        .param("priceCategory", "aa"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(StoreErrorCode.INVALID_PRICE_CATEGORY.getMessage()));
+    }
+
+    @Test
+    @DisplayName("옳바른 정렬값을 주지 않으면 실패한다.")
+    void failGetStoresWithInvalidSortOption() throws Exception {
+        mockMvc.perform(get("/api/v2/stores")
+                        .param("sortOption", "aa"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(StoreErrorCode.INVALID_SORT_OPTION.getMessage()));
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/api/store/controller/StoreControllerTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/store/controller/StoreControllerTest.java
@@ -86,7 +86,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("옳바른 카테고리 필터값을 주지 않으면 실패한다.")
+    @DisplayName("올바른 카테고리 필터값을 주지 않으면 실패한다.")
     void failGetStoresWithInvalidCategoryOption() throws Exception {
         mockMvc.perform(get("/api/v2/stores")
                         .param("storeCategory", "aa"))
@@ -95,7 +95,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("옳바른 가격대 필터값을 주지 않으면 실패한다.")
+    @DisplayName("올바른 가격대 필터값을 주지 않으면 실패한다.")
     void failGetStoresWithInvalidPriceOption() throws Exception {
         mockMvc.perform(get("/api/v2/stores")
                         .param("priceCategory", "aa"))
@@ -104,7 +104,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("옳바른 정렬값을 주지 않으면 실패한다.")
+    @DisplayName("올바른 정렬값을 주지 않으면 실패한다.")
     void failGetStoresWithInvalidSortOption() throws Exception {
         mockMvc.perform(get("/api/v2/stores")
                         .param("sortOption", "aa"))

--- a/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
@@ -1,0 +1,635 @@
+package org.hankki.hankkiserver.api.store.service;
+
+import org.assertj.core.api.Assertions;
+import org.hankki.hankkiserver.ServiceSliceTest;
+import org.hankki.hankkiserver.api.store.parameter.PriceCategory;
+import org.hankki.hankkiserver.api.store.parameter.SortOption;
+import org.hankki.hankkiserver.api.store.service.response.CustomCursor;
+import org.hankki.hankkiserver.api.store.service.response.StorePageResponse;
+import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+import org.hankki.hankkiserver.domain.store.repository.StoreRepository;
+import org.hankki.hankkiserver.domain.university.model.University;
+import org.hankki.hankkiserver.domain.university.repository.UniversityRepository;
+import org.hankki.hankkiserver.domain.universitystore.model.UniversityStore;
+import org.hankki.hankkiserver.domain.universitystore.repository.UniversityStoreRepository;
+import org.hankki.hankkiserver.fixture.StoreFixture;
+import org.hankki.hankkiserver.fixture.UniversityFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StoreQueryServiceTest extends ServiceSliceTest {
+
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    StoreQueryService storeQueryService;
+    @Autowired
+    UniversityStoreRepository universityStoreRepository;
+    @Autowired
+    UniversityRepository universityRepository;
+
+    @Nested
+    @DisplayName("대학 필터 없이 조회시")
+    class GetStoreWithoutUniversityFilter {
+
+        @Nested
+        @DisplayName("가격순 정렬")
+        class SortByPrice {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(10);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6900);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name9");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(10L, 6900, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(20);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(7900);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name19");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(20L, 7900, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+
+            @Test
+            @DisplayName("가격이 모두 동일할 때, 커서가 없다면 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithoutCursorWhenAllPriceSame() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6000);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+
+            }
+
+            @Test
+            @DisplayName("가격이 모두 동일하다면, 커서에 따라 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithCursorWhenAllPriceSame() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(11L, 6000, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6000);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("좋아요순 정렬")
+        class SortByRecommended {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(10);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(91);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name9");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(10L, null, 91));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(20);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(81);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name19");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(20L, null, 81));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+
+            @Test
+            @DisplayName("좋아요가 모두 동일할 때, 커서가 없다면 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithoutCursorWhenAllHeartCountSame() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(100);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+
+            }
+
+            @Test
+            @DisplayName("좋아요가 모두 동일할 때, 커서에 따라 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithCursorWhenAllHeartCountSame() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(11L,null, 100));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(100);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("최신순 정렬")
+        class SortByLatest {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(11L, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i*100, 100 - i));
+                }
+                for (int i = 0; i < 20; i++) {
+                    storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(1L, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("대학 필터 포함하여 조회시")
+    class GetStoreWithUniversityFilter {
+
+        @Nested
+        @DisplayName("가격순 정렬")
+        class SortByPrice {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(1L, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(10);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6900);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name9");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(1L, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(10L, 6900, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(20);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(7900);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name19");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000 + i * 100, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(1L, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(20L, 7900, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+
+            @Test
+            @DisplayName("가격이 모두 동일할 때, 커서가 없다면 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithoutCursorWhenAllPriceSame() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(1L, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6000);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+
+            }
+
+            @Test
+            @DisplayName("가격이 모두 동일하다면, 커서에 따라 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithCursorWhenAllPriceSame() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LOWESTPRICE, new CustomCursor(11L, 6000, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isEqualTo(6000);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("좋아요순 정렬")
+        class SortByRecommended {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(10);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(91);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name9");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(10L, null, 91));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(20);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(81);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name19");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(20L, null, 81));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+
+            @Test
+            @DisplayName("좋아요가 모두 동일할 때, 커서가 없다면 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithoutCursorWhenAllHeartCountSame() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(100);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+
+            }
+
+            @Test
+            @DisplayName("좋아요가 모두 동일할 때, 커서에 따라 식별자 내림차순으로 정렬한다.")
+            void getStoreV2WithCursorWhenAllHeartCountSame() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.RECOMMENDED, new CustomCursor(11L,null, 100));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isEqualTo(100);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("최신순 정렬")
+        class SortByLatest {
+
+            @Test
+            @DisplayName("커서가 없다면 첫 페이지 결과를 반환한다.")
+            void getStoreV2WithoutCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(null, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isTrue();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(11);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name10");
+            }
+
+            @Test
+            @DisplayName("커서에 따라 결과를 반환한다.")
+            void getStoreV2WithCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(11L, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(10);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isEqualTo(1);
+                Assertions.assertThat(storesV2.stores().get(9).name()).isEqualTo("name0");
+            }
+
+            @Test
+            @DisplayName("다음 페이지가 없는 요청으로 받은 커서로 요청시 빈 페이지를 반환한다.")
+            void getStoreV2WithLastCursor() {
+                // given
+                University university = universityRepository.save(UniversityFixture.create());
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.KOREAN, 6000, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                for (int i = 0; i < 20; i++) {
+                    Store store = storeRepository.save(StoreFixture.create("name" + i, StoreCategory.JAPANESE, 6000 + i, 100 - i));
+                    universityStoreRepository.save(UniversityStore.create(store, university));
+                }
+                // when
+                StorePageResponse storesV2 = storeQueryService.getStoresV2(null, StoreCategory.KOREAN, PriceCategory.K8, SortOption.LATEST, new CustomCursor(1L, null, null));
+                // then
+                Assertions.assertThat(storesV2.stores()).hasSize(0);
+                Assertions.assertThat(storesV2.hasNext()).isFalse();
+                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
+                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+            }
+        }
+
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
@@ -94,9 +94,8 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
+
             }
 
             @Test
@@ -201,9 +200,8 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
+
             }
 
             @Test
@@ -305,9 +303,7 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
             }
         }
 

--- a/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
+++ b/src/test/java/org/hankki/hankkiserver/api/store/service/StoreQueryServiceTest.java
@@ -95,7 +95,6 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
                 Assertions.assertThat(storesV2.cursor()).isNull();
-
             }
 
             @Test
@@ -306,7 +305,6 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 Assertions.assertThat(storesV2.cursor()).isNull();
             }
         }
-
     }
 
     @Nested
@@ -381,9 +379,7 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
             }
 
             @Test
@@ -502,9 +498,7 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
             }
 
             @Test
@@ -621,9 +615,7 @@ class StoreQueryServiceTest extends ServiceSliceTest {
                 // then
                 Assertions.assertThat(storesV2.stores()).hasSize(0);
                 Assertions.assertThat(storesV2.hasNext()).isFalse();
-                Assertions.assertThat(storesV2.cursor().nextId()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextHeartCount()).isNull();
-                Assertions.assertThat(storesV2.cursor().nextLowestPrice()).isNull();
+                Assertions.assertThat(storesV2.cursor()).isNull();
             }
         }
 

--- a/src/test/java/org/hankki/hankkiserver/fixture/StoreFixture.java
+++ b/src/test/java/org/hankki/hankkiserver/fixture/StoreFixture.java
@@ -1,0 +1,23 @@
+package org.hankki.hankkiserver.fixture;
+
+
+import org.hankki.hankkiserver.domain.common.Point;
+import org.hankki.hankkiserver.domain.store.model.Store;
+import org.hankki.hankkiserver.domain.store.model.StoreCategory;
+
+public abstract class StoreFixture {
+    private StoreFixture() {
+    }
+
+    public static Store create(String name, StoreCategory category, int lowestPrice, int heartCount) {
+        return Store.builder()
+                .name(name)
+                .point(new Point(1.0, 1.0))
+                .address("address")
+                .category(category)
+                .lowestPrice(lowestPrice)
+                .heartCount(heartCount)
+                .isDeleted(false)
+                .build();
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/fixture/UniversityFixture.java
+++ b/src/test/java/org/hankki/hankkiserver/fixture/UniversityFixture.java
@@ -1,0 +1,16 @@
+package org.hankki.hankkiserver.fixture;
+
+import org.hankki.hankkiserver.domain.common.Point;
+import org.hankki.hankkiserver.domain.university.model.University;
+
+public abstract class UniversityFixture {
+    private UniversityFixture() {
+    }
+
+    public static University create() {
+        return University.builder()
+                .name("university")
+                .point(new Point(1.0, 1.0))
+                .build();
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/util/DatabaseCleaner.java
+++ b/src/test/java/org/hankki/hankkiserver/util/DatabaseCleaner.java
@@ -1,0 +1,55 @@
+package org.hankki.hankkiserver.util;
+
+import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+    @Autowired
+    private EntityManager entityManager;
+
+    @Transactional
+    public void cleanUp() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = FALSE").executeUpdate();
+        for (String tableName : getTableNames()) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+//            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_ID" + " RESTART WITH 1")
+//                    .executeUpdate();
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = TRUE").executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        return entityManager.getMetamodel().getEntities().stream()
+                .filter(entity -> entity.getJavaType().isAnnotationPresent(Entity.class))
+                .map(entityType -> {
+                    Table tableAnnotation = entityType.getJavaType().getAnnotation(Table.class);
+                    if (tableAnnotation != null && !tableAnnotation.name().isBlank()) {
+                        return tableAnnotation.name();
+                    } else {
+                        return camelToSnake(entityType.getName());
+                    }
+                })
+                .toList();
+    }
+
+    private String camelToSnake(String camel) {
+        StringBuilder snake = new StringBuilder();
+        for (char c : camel.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                snake.append("_");
+            }
+            snake.append(Character.toLowerCase(c));
+        }
+        if (snake.charAt(0) == '_') {
+            snake.deleteCharAt(0);
+        }
+        return snake.toString();
+    }
+}

--- a/src/test/java/org/hankki/hankkiserver/util/DatabaseCleanerExtension.java
+++ b/src/test/java/org/hankki/hankkiserver/util/DatabaseCleanerExtension.java
@@ -1,0 +1,13 @@
+package org.hankki.hankkiserver.util;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DatabaseCleaner databaseCleaner = SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+        databaseCleaner.cleanUp();
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
close #240 

## Description ✔️
- 커서기반 페이지네이션 구현
- 페이지네이션시 동일한 커서값에 의한  데이터 유실 방지 위한 커스텀 커서 구현

## To Reviewers
- 정렬, 필터값에 따라 조인여부가 달라지는데, 이것까지 동적으로 하는 방법은 없는 것 같아서 service에서 조인여부에 따라 분기처리 한번 했습니다.
- 테스트 코드, 구성 제외하면 그렇게 많지 않습니다. 쿼리 위주로 봐주세요

